### PR TITLE
fix(edge-worker): let repository.model win over the global default when no explicit model is requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
+- Per-repository `model` and `fallbackModel` configuration is now respected when no model label or description tag is present (previously the global default always won for both), and is only applied when it's compatible with the resolved agent — an agent-only selection (for example a `codex` or `gemini` label with no model tag) no longer hands a foreign-runner model string like a Claude model name to the wrong runner, including on session-continuation runner switches. Cursor sessions still accept GPT model ids directly (for example `gpt-5.4`), since Cursor supports those models natively. ([#1360](https://github.com/cyrusagents/cyrus/pull/1360))
 
 ### Changed
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.173` to `0.3.185` and `@anthropic-ai/sdk` from `^0.104.1` to `^0.105.0`, bringing in the latest Claude Code capabilities and bug fixes. ([CYPACK-1346](https://linear.app/ceedar/issue/CYPACK-1346), [#1342](https://github.com/cyrusagents/cyrus/pull/1342))

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -62,6 +62,12 @@ export interface IRunnerSelector {
 	};
 	getDefaultModelForRunner(runnerType: RunnerType): string;
 	getDefaultFallbackModelForRunner(runnerType: RunnerType): string;
+	inferFallbackModel(model: string, runnerType: RunnerType): string | undefined;
+	inferRunnerFromModel(model?: string): RunnerType | undefined;
+	isModelCompatibleWithRunner(
+		model: string | undefined,
+		runnerType: RunnerType,
+	): boolean;
 }
 
 /**
@@ -331,26 +337,27 @@ export class RunnerConfigBuilder {
 		let fallbackModelOverride = runnerSelection.fallbackModelOverride;
 
 		// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
+		// Discard any cross-runner selector override rather than default-filling
+		// it — the compatibility gate below (repositoryModelIsCompatible /
+		// repositoryFallbackModelIsCompatible) now structurally prevents a
+		// foreign-runner repository.model/fallbackModel from leaking through,
+		// so repository config can safely resolve on the finalModel chain.
 		if (input.session.claudeSessionId && runnerType !== "claude") {
 			runnerType = "claude";
-			modelOverride = this.runnerSelector.getDefaultModelForRunner("claude");
-			fallbackModelOverride =
-				this.runnerSelector.getDefaultFallbackModelForRunner("claude");
+			modelOverride = undefined;
+			fallbackModelOverride = undefined;
 		} else if (input.session.geminiSessionId && runnerType !== "gemini") {
 			runnerType = "gemini";
-			modelOverride = this.runnerSelector.getDefaultModelForRunner("gemini");
-			fallbackModelOverride =
-				this.runnerSelector.getDefaultFallbackModelForRunner("gemini");
+			modelOverride = undefined;
+			fallbackModelOverride = undefined;
 		} else if (input.session.codexSessionId && runnerType !== "codex") {
 			runnerType = "codex";
-			modelOverride = this.runnerSelector.getDefaultModelForRunner("codex");
-			fallbackModelOverride =
-				this.runnerSelector.getDefaultFallbackModelForRunner("codex");
+			modelOverride = undefined;
+			fallbackModelOverride = undefined;
 		} else if (input.session.cursorSessionId && runnerType !== "cursor") {
 			runnerType = "cursor";
-			modelOverride = this.runnerSelector.getDefaultModelForRunner("cursor");
-			fallbackModelOverride =
-				this.runnerSelector.getDefaultFallbackModelForRunner("cursor");
+			modelOverride = undefined;
+			fallbackModelOverride = undefined;
 		}
 
 		// Log model override if found
@@ -358,10 +365,42 @@ export class RunnerConfigBuilder {
 			log.debug(`Model override via selector: ${modelOverride}`);
 		}
 
+		// A repository.model / repository.fallbackModel string only applies when
+		// it's compatible with the resolved runnerType (see
+		// RunnerSelectionService.isModelCompatibleWithRunner — no evidence of a
+		// different runner, an exact match, or a GPT-shaped model on Cursor,
+		// which accepts GPT model ids directly). Otherwise an agent-only
+		// selection (e.g. label "codex" with no model tag) would still hand a
+		// foreign-runner repository.model (e.g. a Claude string like "sonnet")
+		// to a Codex/Gemini/Cursor session.
+		const repositoryModelIsCompatible =
+			this.runnerSelector.isModelCompatibleWithRunner(
+				input.repository.model,
+				runnerType,
+			);
+		if (input.repository.model && !repositoryModelIsCompatible) {
+			log.debug(
+				`Skipping repository.model "${input.repository.model}" — incompatible with resolved runnerType "${runnerType}"`,
+			);
+		}
+		const repositoryFallbackModelIsCompatible =
+			this.runnerSelector.isModelCompatibleWithRunner(
+				input.repository.fallbackModel,
+				runnerType,
+			);
+		if (
+			input.repository.fallbackModel &&
+			!repositoryFallbackModelIsCompatible
+		) {
+			log.debug(
+				`Skipping repository.fallbackModel "${input.repository.fallbackModel}" — incompatible with resolved runnerType "${runnerType}"`,
+			);
+		}
+
 		// Determine final model from selectors, repository override, then runner-specific defaults
 		const finalModel =
 			modelOverride ||
-			input.repository.model ||
+			(repositoryModelIsCompatible ? input.repository.model : undefined) ||
 			this.runnerSelector.getDefaultModelForRunner(runnerType);
 
 		const resolvedWorkspaceId =
@@ -415,9 +454,19 @@ export class RunnerConfigBuilder {
 			),
 			// Priority order: label override > repository config > global default
 			model: finalModel,
+			// Priority order: label override > repository config (only when
+			// compatible with runnerType, same gate as repository.model above) >
+			// inferred from the resolved primary model (e.g. "sonnet" -> "haiku")
+			// > runner-wide default. The inferred step keeps a real step-down
+			// fallback even when no explicit override was requested (e.g.
+			// `claudeDefaultModel: "sonnet"` with no repository.fallbackModel
+			// should not fall back to "sonnet").
 			fallbackModel:
 				fallbackModelOverride ||
-				input.repository.fallbackModel ||
+				(repositoryFallbackModelIsCompatible
+					? input.repository.fallbackModel
+					: undefined) ||
+				this.runnerSelector.inferFallbackModel(finalModel, runnerType) ||
 				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType),
 			logger: log,
 			hooks,

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -92,6 +92,108 @@ export class RunnerSelectionService {
 	}
 
 	/**
+	 * Detect whether a model name looks like a Codex/GPT model.
+	 */
+	private isCodexModel(model: string): boolean {
+		return (
+			/gpt-[a-z0-9.-]*codex$/i.test(model) || /^gpt-[a-z0-9.-]+$/i.test(model)
+		);
+	}
+
+	/**
+	 * Infer which runner a model name implies, if any — e.g. "opus" -> claude,
+	 * "gemini-2.5-pro" -> gemini, a GPT/Codex-shaped name -> codex. Returns
+	 * undefined when the model name gives no evidence either way (custom /
+	 * proxy model names, or an unset model).
+	 */
+	public inferRunnerFromModel(model?: string): RunnerType | undefined {
+		if (!model) return undefined;
+		const normalizedModel = model.toLowerCase();
+		if (normalizedModel.startsWith("gemini")) return "gemini";
+		if (
+			normalizedModel === "fable" ||
+			normalizedModel === "opus" ||
+			normalizedModel === "sonnet" ||
+			normalizedModel === "haiku" ||
+			normalizedModel.startsWith("claude")
+		) {
+			return "claude";
+		}
+		if (this.isCodexModel(normalizedModel)) return "codex";
+		return undefined;
+	}
+
+	/**
+	 * Whether a model name is compatible with a given runner type — i.e. safe
+	 * to hand that model string to that runner. Compatible when:
+	 * - `inferRunnerFromModel(model)` is undefined (no evidence either way,
+	 *   e.g. a custom/proxy model name — assume compatible), OR
+	 * - it equals `runnerType` exactly, OR
+	 * - the model looks like a Codex/GPT model and `runnerType` is "cursor"
+	 *   (Cursor accepts GPT model ids directly — see
+	 *   `CursorRunner.normalizeCursorModel` and the `cursorDefaultModel`
+	 *   schema docs in `packages/core/src/config-schemas.ts`).
+	 */
+	public isModelCompatibleWithRunner(
+		model: string | undefined,
+		runnerType: RunnerType,
+	): boolean {
+		const inferredRunner = this.inferRunnerFromModel(model);
+		if (inferredRunner === undefined) return true;
+		if (inferredRunner === runnerType) return true;
+		if (inferredRunner === "codex" && runnerType === "cursor") return true;
+		return false;
+	}
+
+	/**
+	 * Infer a sensible fallback (retry) model for a given primary model and
+	 * runner type — e.g. "opus" -> "sonnet" for Claude, one tier down for
+	 * Gemini, etc. Used both to infer a fallback for an explicit model
+	 * override, and (via `RunnerConfigBuilder`) to infer a fallback for the
+	 * *resolved* primary model when no explicit override was requested.
+	 */
+	public inferFallbackModel(
+		model: string,
+		runnerType: RunnerType,
+	): string | undefined {
+		const normalizedModel = model.toLowerCase();
+		if (runnerType === "claude") {
+			if (normalizedModel === "fable") return "opus";
+			if (normalizedModel === "opus") return "sonnet";
+			if (normalizedModel === "sonnet") return "haiku";
+			// Keep haiku fallback on sonnet for retry behavior
+			if (normalizedModel === "haiku") return "sonnet";
+			return "sonnet";
+		}
+		if (runnerType === "gemini") {
+			if (
+				normalizedModel === "gemini-3" ||
+				normalizedModel === "gemini-3-pro" ||
+				normalizedModel === "gemini-3-pro-preview"
+			) {
+				return "gemini-2.5-pro";
+			}
+			if (
+				normalizedModel === "gemini-2.5-pro" ||
+				normalizedModel === "gemini-2.5"
+			) {
+				return "gemini-2.5-flash";
+			}
+			if (normalizedModel === "gemini-2.5-flash") {
+				return "gemini-2.5-flash-lite";
+			}
+			if (normalizedModel === "gemini-2.5-flash-lite") {
+				return "gemini-2.5-flash-lite";
+			}
+			return "gemini-2.5-flash";
+		}
+		if (this.isCodexModel(normalizedModel)) {
+			return "gpt-5.2-codex";
+		}
+		return "gpt-5";
+	}
+
+	/**
 	 * Parse a bracketed tag from issue description.
 	 *
 	 * Supports escaped brackets (`\\[tag=value\\]`) which Linear can emit.
@@ -141,80 +243,6 @@ export class RunnerSelectionService {
 			"model",
 		);
 
-		const defaultModelByRunner: Record<RunnerType, string> = {
-			claude: this.getDefaultModelForRunner("claude"),
-			gemini: this.getDefaultModelForRunner("gemini"),
-			codex: this.getDefaultModelForRunner("codex"),
-			cursor: this.getDefaultModelForRunner("cursor"),
-		};
-		const defaultFallbackByRunner: Record<RunnerType, string> = {
-			claude: this.getDefaultFallbackModelForRunner("claude"),
-			gemini: this.getDefaultFallbackModelForRunner("gemini"),
-			codex: this.getDefaultFallbackModelForRunner("codex"),
-			cursor: this.getDefaultFallbackModelForRunner("cursor"),
-		};
-
-		const isCodexModel = (model: string): boolean =>
-			/gpt-[a-z0-9.-]*codex$/i.test(model) || /^gpt-[a-z0-9.-]+$/i.test(model);
-
-		const inferRunnerFromModel = (model?: string): RunnerType | undefined => {
-			if (!model) return undefined;
-			const normalizedModel = model.toLowerCase();
-			if (normalizedModel.startsWith("gemini")) return "gemini";
-			if (
-				normalizedModel === "fable" ||
-				normalizedModel === "opus" ||
-				normalizedModel === "sonnet" ||
-				normalizedModel === "haiku" ||
-				normalizedModel.startsWith("claude")
-			) {
-				return "claude";
-			}
-			if (isCodexModel(normalizedModel)) return "codex";
-			return undefined;
-		};
-
-		const inferFallbackModel = (
-			model: string,
-			runnerType: RunnerType,
-		): string | undefined => {
-			const normalizedModel = model.toLowerCase();
-			if (runnerType === "claude") {
-				if (normalizedModel === "fable") return "opus";
-				if (normalizedModel === "opus") return "sonnet";
-				if (normalizedModel === "sonnet") return "haiku";
-				// Keep haiku fallback on sonnet for retry behavior
-				if (normalizedModel === "haiku") return "sonnet";
-				return "sonnet";
-			}
-			if (runnerType === "gemini") {
-				if (
-					normalizedModel === "gemini-3" ||
-					normalizedModel === "gemini-3-pro" ||
-					normalizedModel === "gemini-3-pro-preview"
-				) {
-					return "gemini-2.5-pro";
-				}
-				if (
-					normalizedModel === "gemini-2.5-pro" ||
-					normalizedModel === "gemini-2.5"
-				) {
-					return "gemini-2.5-flash";
-				}
-				if (normalizedModel === "gemini-2.5-flash") {
-					return "gemini-2.5-flash-lite";
-				}
-				if (normalizedModel === "gemini-2.5-flash-lite") {
-					return "gemini-2.5-flash-lite";
-				}
-				return "gemini-2.5-flash";
-			}
-			if (isCodexModel(normalizedModel)) {
-				return "gpt-5.2-codex";
-			}
-			return "gpt-5";
-		};
-
 		const resolveAgentFromLabel = (
 			lowercaseLabels: string[],
 		): RunnerType | undefined => {
@@ -240,7 +268,7 @@ export class RunnerSelectionService {
 			lowercaseLabels: string[],
 		): string | undefined => {
 			const codexModelLabel = lowercaseLabels.find((label) =>
-				isCodexModel(label),
+				this.isCodexModel(label),
 			);
 			if (codexModelLabel) {
 				return codexModelLabel;
@@ -294,32 +322,23 @@ export class RunnerSelectionService {
 		const runnerType: RunnerType =
 			resolvedAgentFromDescription ||
 			resolvedAgentFromLabels ||
-			inferRunnerFromModel(explicitModel) ||
+			this.inferRunnerFromModel(explicitModel) ||
 			this.getDefaultRunner();
 
 		// If an explicit agent conflicts with model's implied runner, keep the agent and reset model.
-		const modelRunner = inferRunnerFromModel(explicitModel);
+		const modelRunner = this.inferRunnerFromModel(explicitModel);
 		let modelOverride = explicitModel;
 		if (modelOverride && modelRunner && modelRunner !== runnerType) {
 			modelOverride = undefined;
 		}
 
-		const resolvedModelOverride =
-			modelOverride ||
-			defaultModelByRunner[runnerType] ||
-			this.getDefaultModelForRunner(runnerType);
-
-		let fallbackModelOverride = inferFallbackModel(
-			resolvedModelOverride,
-			runnerType,
-		);
-		if (!fallbackModelOverride) {
-			fallbackModelOverride = defaultFallbackByRunner[runnerType];
-		}
+		const fallbackModelOverride = modelOverride
+			? this.inferFallbackModel(modelOverride, runnerType)
+			: undefined;
 
 		return {
 			runnerType,
-			modelOverride: resolvedModelOverride,
+			modelOverride,
 			fallbackModelOverride,
 		};
 	}

--- a/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
+++ b/packages/edge-worker/test/EdgeWorker.runner-selection.test.ts
@@ -1105,7 +1105,27 @@ Issue: {{issue_identifier}}`;
 			]);
 
 			expect(runnerSelection.runnerType).toBe("claude");
+			expect(runnerSelection.modelOverride).toBeUndefined();
+		});
+
+		it("should return no modelOverride/fallbackModelOverride when no labels or description tag request a model", () => {
+			const runnerSelection = (
+				edgeWorker as any
+			).runnerSelectionService.determineRunnerSelection([]);
+
+			expect(runnerSelection.runnerType).toBe("claude");
+			expect(runnerSelection.modelOverride).toBeUndefined();
+			expect(runnerSelection.fallbackModelOverride).toBeUndefined();
+		});
+
+		it("should still resolve an explicit model label to modelOverride (regression guard)", () => {
+			const runnerSelection = (
+				edgeWorker as any
+			).runnerSelectionService.determineRunnerSelection(["opus"]);
+
+			expect(runnerSelection.runnerType).toBe("claude");
 			expect(runnerSelection.modelOverride).toBe("opus");
+			expect(runnerSelection.fallbackModelOverride).toBe("sonnet");
 		});
 	});
 

--- a/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.additional-directories.test.ts
@@ -27,6 +27,9 @@ function makeBuilder(): RunnerConfigBuilder {
 		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
 		getDefaultModelForRunner: () => "opus",
 		getDefaultFallbackModelForRunner: () => "sonnet",
+		inferFallbackModel: () => undefined,
+		inferRunnerFromModel: () => undefined,
+		isModelCompatibleWithRunner: () => true,
 	};
 	return new RunnerConfigBuilder(
 		chatToolResolver,

--- a/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
@@ -27,6 +27,9 @@ function makeBuilder(): RunnerConfigBuilder {
 		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
 		getDefaultModelForRunner: () => "",
 		getDefaultFallbackModelForRunner: () => "",
+		inferFallbackModel: () => undefined,
+		inferRunnerFromModel: () => undefined,
+		isModelCompatibleWithRunner: () => true,
 	};
 	return new RunnerConfigBuilder(
 		chatToolResolver,

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-sandbox.test.ts
@@ -26,6 +26,9 @@ function makeCodexBuilder(): RunnerConfigBuilder {
 		determineRunnerSelection: () => ({ runnerType: "codex" as const }),
 		getDefaultModelForRunner: () => "gpt-5.5",
 		getDefaultFallbackModelForRunner: () => "gpt-5.4",
+		inferFallbackModel: () => undefined,
+		inferRunnerFromModel: () => undefined,
+		isModelCompatibleWithRunner: () => true,
 	};
 	return new RunnerConfigBuilder(
 		chatToolResolver,

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
@@ -26,6 +26,9 @@ function makeBuilder(): RunnerConfigBuilder {
 		determineRunnerSelection: () => ({ runnerType: "codex" as const }),
 		getDefaultModelForRunner: () => "gpt-5.5",
 		getDefaultFallbackModelForRunner: () => "gpt-5.2-codex",
+		inferFallbackModel: () => undefined,
+		inferRunnerFromModel: () => undefined,
+		isModelCompatibleWithRunner: () => true,
 	};
 	return new RunnerConfigBuilder(
 		chatToolResolver,

--- a/packages/edge-worker/test/RunnerConfigBuilder.model-precedence.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.model-precedence.test.ts
@@ -1,0 +1,236 @@
+import type {
+	CyrusAgentSession,
+	EdgeWorkerConfig,
+	ILogger,
+	RepositoryConfig,
+} from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+import { RunnerSelectionService } from "../src/RunnerSelectionService.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(config: Partial<EdgeWorkerConfig>): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	// Real selector, not a mock — these tests exercise selector + builder
+	// end-to-end. `defaultRunner: "claude"` is set explicitly so the tests
+	// are hermetic against env-based auto-detection (getDefaultRunner()
+	// falls through to process.env.GEMINI_API_KEY / etc when unset).
+	const runnerSelector = new RunnerSelectionService({
+		defaultRunner: "claude",
+		...config,
+	} as EdgeWorkerConfig);
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function makeRepository(
+	overrides: Partial<RepositoryConfig> = {},
+): RepositoryConfig {
+	return {
+		id: "repo-a",
+		name: "Repo A",
+		repositoryPath: "/repos/repo-a",
+		allowedTools: [],
+		...overrides,
+	} as unknown as RepositoryConfig;
+}
+
+function makeSession(
+	overrides: Partial<CyrusAgentSession> = {},
+): CyrusAgentSession {
+	return {
+		issueId: "issue-1",
+		issue: { identifier: "ABC-1" },
+		workspace: { path: "/ws/repo-a-worktree", isGitWorktree: true },
+		...overrides,
+	} as unknown as CyrusAgentSession;
+}
+
+function buildIssueConfig(
+	builder: RunnerConfigBuilder,
+	repository: RepositoryConfig,
+	labels: string[] = [],
+	issueDescription?: string,
+	session: CyrusAgentSession = makeSession(),
+) {
+	return builder.buildIssueConfig({
+		session,
+		repository,
+		sessionId: "sess-1",
+		systemPrompt: "test",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/repos/repo-a"],
+		disallowedTools: [],
+		cyrusHome: "/tmp/cyrus-home",
+		linearWorkspaceId: "ws-1",
+		labels,
+		issueDescription,
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "ws-1",
+	});
+}
+
+describe("RunnerConfigBuilder model precedence (label/tag > repository.model > global default), end-to-end with the real RunnerSelectionService", () => {
+	it("falls back to repository.model when no label or description tag requests a model", () => {
+		const builder = makeBuilder({});
+		const repository = makeRepository({ model: "claude-fable-5" });
+
+		const { config } = buildIssueConfig(builder, repository);
+
+		expect(config.model).toBe("claude-fable-5");
+	});
+
+	it("prefers an explicit model label over repository.model", () => {
+		const builder = makeBuilder({});
+		const repository = makeRepository({ model: "claude-fable-5" });
+
+		const { config } = buildIssueConfig(builder, repository, ["sonnet"]);
+
+		expect(config.model).toBe("sonnet");
+	});
+
+	it("falls back to the global default when neither a label/tag nor repository.model is set", () => {
+		const builder = makeBuilder({});
+		const repository = makeRepository();
+
+		const { config } = buildIssueConfig(builder, repository);
+
+		expect(config.model).toBe("opus");
+	});
+
+	it("infers the fallback model from the resolved primary model when no explicit override or repository.fallbackModel is set (regression guard for org-level claudeDefaultModel)", () => {
+		const builder = makeBuilder({ claudeDefaultModel: "sonnet" });
+		const repository = makeRepository();
+
+		const { config } = buildIssueConfig(builder, repository);
+
+		expect(config.model).toBe("sonnet");
+		expect(config.fallbackModel).toBe("haiku");
+	});
+
+	describe("cross-runner repository.model compatibility gate (agent-only selection, no model tag)", () => {
+		it("does not hand a foreign Claude-shaped repository.model to a codex-labeled session", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "sonnet" });
+
+			const { config } = buildIssueConfig(builder, repository, ["codex"]);
+
+			expect(config.model).toBe("gpt-5.5");
+			expect(config.fallbackModel).toBe("gpt-5.2-codex");
+		});
+
+		it("does not hand a foreign Claude-shaped repository.model to a gemini-labeled session", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "sonnet" });
+
+			const { config } = buildIssueConfig(builder, repository, ["gemini"]);
+
+			expect(config.model).toBe("gemini-2.5-pro");
+			expect(config.fallbackModel).toBe("gemini-2.5-flash");
+		});
+
+		it("does not hand a foreign Claude-shaped repository.model to a [agent=codex] description-tag session", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "sonnet" });
+
+			const { config } = buildIssueConfig(
+				builder,
+				repository,
+				[],
+				"[agent=codex]",
+			);
+
+			expect(config.model).toBe("gpt-5.5");
+		});
+
+		it("still applies repository.model when it's compatible with the resolved runner (claude)", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "sonnet" });
+
+			const { config } = buildIssueConfig(builder, repository, ["claude"]);
+
+			expect(config.model).toBe("sonnet");
+		});
+
+		it("still applies an unrecognizable/custom repository.model regardless of runner (no evidence of incompatibility)", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "my-custom-model" });
+
+			const { config } = buildIssueConfig(builder, repository, ["codex"]);
+
+			expect(config.model).toBe("my-custom-model");
+		});
+
+		it("applies a GPT-shaped repository.model to a cursor-labeled session (Cursor accepts GPT model ids directly)", () => {
+			const builder = makeBuilder({});
+			const repository = makeRepository({ model: "gpt-5.4" });
+
+			const { config } = buildIssueConfig(builder, repository, ["cursor"]);
+
+			expect(config.model).toBe("gpt-5.4");
+		});
+	});
+
+	describe("cross-runner repository.model compatibility gate on resume-switch (label-changed session continuation)", () => {
+		it("applies repository.model on a resume-switch when it's compatible with the runner the session is forced back to", () => {
+			const builder = makeBuilder({ defaultRunner: "codex" });
+			const repository = makeRepository({ model: "sonnet" });
+			const session = makeSession({ claudeSessionId: "existing-claude-id" });
+
+			// No labels -> selector resolves to the configured default ("codex"),
+			// but the session already has a claudeSessionId, forcing a resume
+			// back onto claude. repository.model ("sonnet") is compatible with
+			// claude, so it should still apply.
+			const { config } = buildIssueConfig(
+				builder,
+				repository,
+				[],
+				undefined,
+				session,
+			);
+
+			expect(config.model).toBe("sonnet");
+		});
+
+		it("skips repository.model on a resume-switch when it's incompatible with the runner the session is forced back to", () => {
+			const builder = makeBuilder({ defaultRunner: "codex" });
+			const repository = makeRepository({ model: "gemini-2.5-pro" });
+			const session = makeSession({ claudeSessionId: "existing-claude-id" });
+
+			// Same resume-switch as above, but repository.model is Gemini-shaped
+			// — incompatible with the claude runner the session is forced back
+			// to, so the gate must block it and fall through to the claude
+			// default instead.
+			const { config } = buildIssueConfig(
+				builder,
+				repository,
+				[],
+				undefined,
+				session,
+			);
+
+			expect(config.model).toBe("opus");
+		});
+	});
+});


### PR DESCRIPTION
# fix(edge-worker): let `repository.model` win over the global default when no explicit model is requested

## The bug

The per-repository `model` config field is unreachable. `RunnerSelectionService.determineRunnerSelection()` always resolves `modelOverride` to a value — when no model label or `[model=...]` description tag is present, it fills in the global default (`claudeDefaultModel || defaultModel || "opus"`):

```ts
const resolvedModelOverride =
    modelOverride ||
    defaultModelByRunner[runnerType] ||
    this.getDefaultModelForRunner(runnerType);
```

Then in `RunnerConfigBuilder.buildIssueConfig()`:

```ts
const finalModel =
    modelOverride ||            // ← always set, so…
    input.repository.model ||   // ← …this can never win
    this.runnerSelector.getDefaultModelForRunner(runnerType);
```

The comment on the config says `// Priority order: label override > repository config > global default`, but in practice the repository tier is dead code. The same applies to `repository.fallbackModel` (shadowed by the always-inferred `fallbackModelOverride`).

**Real-world symptom:** a self-hosted user pins `"model": "claude-opus-4-8"` (or any model) on a repository, configures no global default, and every session still launches with the bare alias `"opus"` — which the bundled SDK resolves to whatever it considers latest, silently ignoring the pin. The Linear timeline shows `Using model: claude-opus-4-7` while the config says otherwise.

## The fix

`determineRunnerSelection()` now returns `modelOverride` / `fallbackModelOverride` **only when a model was explicitly requested** (label or description tag). When nothing explicit is present it returns `undefined` for both, letting the existing precedence chain in `buildIssueConfig()` work as documented:

- `model`: explicit label/tag → `repository.model` → global default (unchanged expression, now reachable).
- `fallbackModel`: explicit override → `repository.fallbackModel` (newly reachable, mirroring the fix) → inferred from the final model via `inferFallbackModel()` (extracted to a public method; preserves the existing behavior where a customized default primary steps its fallback down, e.g. default `sonnet` → fallback `haiku`) → runner-default fallback.

The four resume-runner-switch branches in `buildIssueConfig()` (labels changed on an existing session) now clear their overrides instead of re-filling with the switched-to runner's default, so `repository.model` also resolves on continuation turns — safe because the compatibility gate below blocks any foreign-runner repository model from leaking into a resumed session (covered by a dedicated regression test).

## Cross-runner safety

An agent-only selector (label `codex`/`gemini`/`cursor` or `[agent=...]` tag) with no model tag would otherwise fall through to `repository.model`, handing e.g. a Claude model string to a Codex runner. `buildIssueConfig` therefore gates `repository.model` / `repository.fallbackModel` by runner compatibility (via the extracted `inferRunnerFromModel`): a value is applied only when its inferred runner is unknown (custom/proxy model names still pass) or matches the resolved runner; incompatible values are skipped with a debug log and the runner default applies. Cursor is special-cased: it legitimately runs GPT model ids, so codex-inferred models stay compatible on a cursor runner. Covered by regression tests for the codex/gemini label, `[agent=codex]` tag, cursor+GPT, and resume-switch cases.

## Behavior change

One existing expectation changes: when an explicit model label conflicts with the resolved runner type (e.g. labels `["claude", "gpt-5-codex"]`), the conflicting model is reset and `modelOverride` is now `undefined` (previously the global default) — the final model then resolves through `repository.model` / global default downstream, same effective model when no repo pin exists.

## Tests

- Selector: no labels/tags → both overrides `undefined`; explicit labels still resolve as before.
- Builder precedence (wired through the **real** `RunnerSelectionService`): no label + `repository.model` set → repo model wins; explicit label + `repository.model` set → label wins; neither → global default.
- Fallback: customized default primary with no explicit anything → fallback is inferred from the final model (not the hardcoded runner literal), so the fallback can no longer silently equal the primary.

`pnpm test:packages` green (747/747 in edge-worker), `pnpm typecheck` clean, `pnpm lint` clean on touched files.

## Known follow-up (out of scope here)

`inferFallbackModel()` matches bare aliases (`fable`/`opus`/`sonnet`/`haiku`) but not full versioned IDs, so a `repository.model` like `"claude-fable-5"` gets the generic claude fallback (`sonnet`) rather than the one-tier-down `opus`. The fallback is always a valid same-provider model, so this is a quality nit, not a safety issue — a natural follow-up is prefix-matching in `inferFallbackModel`'s claude branch, mirroring what `inferRunnerFromModel` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAAaJDxxUWmhtYySCfSQHD
