### PR TITLE
BYE-340 route GPT-5.6 labels through Codex runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- GPT-5.6 model labels now select the Codex runner with the requested `gpt-5.6-terra`, `gpt-5.6-luna`, or `gpt-5.6-sol` model and propagate label-based reasoning effort to the OpenAI request instead of silently falling back to Claude Sonnet. ([BYE-340](https://linear.app/byelverton/issue/BYE-340/edgeworker-wire-gpt-56-model-labels-terralunasol-reasoning-effort-into), [#1371](https://github.com/cyrusagents/cyrus/pull/1371))
 - Forwarded and shared Slack messages are now included when you @mention Cyrus. Previously, forwarding a message (for example a Sentry alert) into a channel and @mentioning Cyrus passed along only your typed comment — the forwarded message's contents were dropped, so a forward with no comment gave Cyrus nothing to work with. The forwarded content is now part of the prompt. ([#1326](https://github.com/cyrusagents/cyrus/pull/1326))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Codex sessions now default to `medium` reasoning effort. Previously any `gpt-5*` model was pinned to `high` and every other Codex model inherited whatever the Codex CLI happened to default to, so the effort actually used was neither predictable nor adjustable per issue. You can now set it explicitly by labelling the issue `low`, `medium`, or `high` (the prefixed forms `effort:low` / `effort:medium` / `effort:high` work identically), and the chosen effort reaches OpenAI as the request's `reasoning.effort`. Applying two conflicting effort labels stops the run with an explicit error instead of silently picking one. ([BYE-340](https://linear.app/byelverton/issue/BYE-340/edgeworker-wire-gpt-56-model-labels-terralunasol-reasoning-effort-into), [#1371](https://github.com/cyrusagents/cyrus/pull/1371))
+
 ### Fixed
+- GPT-5.6 model labels now run on the Codex runtime instead of silently falling back to Claude Sonnet. Labelling an issue `terra`, `luna`, or `sol` selects the Codex runner with `gpt-5.6-terra`, `gpt-5.6-luna`, or `gpt-5.6-sol` respectively, and the bare `gpt-5.6` label maps to Sol; the same names work as a `[model=...]` description tag, which takes precedence over labels. Combining one of these with a Claude or Gemini selector, or applying one to an issue whose session is already running on another runtime, now fails with an explicit error naming the conflict rather than quietly dropping the model you asked for. Model-family-shaped labels Cyrus does not recognize are logged before the normal runner fallback applies. ([BYE-340](https://linear.app/byelverton/issue/BYE-340/edgeworker-wire-gpt-56-model-labels-terralunasol-reasoning-effort-into), [#1371](https://github.com/cyrusagents/cyrus/pull/1371))
 - The self-hosted GitHub App setup flow (`cyrus-setup-github` skill, "enable @mentions") no longer fails with "Default events are not supported by permissions: organization". The generated App manifest subscribed to an event with no matching permission, so GitHub rejected the submission and no App was ever created. ([#1406](https://github.com/cyrusagents/cyrus/issues/1406), [#1407](https://github.com/cyrusagents/cyrus/pull/1407))
 
 ### Security

--- a/packages/codex-runner/src/backend/AppServerCodexBackend.ts
+++ b/packages/codex-runner/src/backend/AppServerCodexBackend.ts
@@ -268,6 +268,12 @@ export class AppServerCodexBackend
 			: {};
 		const sandbox = config.sandbox;
 
+		// Codex's app-server accepts this setting in its config namespace and
+		// translates it to the OpenAI request's reasoning.effort field.
+		if (config.modelReasoningEffort) {
+			base.model_reasoning_effort = config.modelReasoningEffort;
+		}
+
 		if (sandbox.kind === "profile") {
 			base.permissions = {
 				[sandbox.profileId]: {

--- a/packages/codex-runner/src/config/CodexConfigBuilder.ts
+++ b/packages/codex-runner/src/config/CodexConfigBuilder.ts
@@ -10,11 +10,8 @@ import type {
 import { buildCodexMcpServersConfig } from "./mcpConfigTranslator.js";
 import { resolveCodexSandbox } from "./sandboxPolicy.js";
 
-function getDefaultReasoningEffortForModel(
-	model?: string,
-): CodexRunnerConfig["modelReasoningEffort"] | undefined {
-	// All gpt-5 variants (including plain "gpt-5") reject xhigh; pin to "high".
-	return /^gpt-5/i.test(model || "") ? "high" : undefined;
+function getDefaultReasoningEffort(): CodexRunnerConfig["modelReasoningEffort"] {
+	return "medium";
 }
 
 /**
@@ -31,8 +28,7 @@ export class CodexConfigBuilder {
 
 		const codexHome = this.resolveCodexHome();
 		const reasoningEffort =
-			this.config.modelReasoningEffort ??
-			getDefaultReasoningEffortForModel(this.config.model);
+			this.config.modelReasoningEffort ?? getDefaultReasoningEffort();
 		const webSearchMode =
 			this.config.webSearchMode ??
 			(this.config.includeWebSearch ? "live" : undefined);

--- a/packages/codex-runner/test/AppServerCodexBackend.test.ts
+++ b/packages/codex-runner/test/AppServerCodexBackend.test.ts
@@ -123,6 +123,21 @@ describe("AppServerCodexBackend", () => {
 		expect(cfg?.mcp_servers).toEqual({ linear: { command: "linear-mcp" } });
 	});
 
+	it("passes reasoning effort through the Codex config namespace", async () => {
+		const { backend, client } = makeBackend();
+		await backend.open({
+			...baseConfig,
+			codexPath: "/bin/true",
+			model: "gpt-5.6-luna",
+			modelReasoningEffort: "high",
+		});
+		const params = client.lastRequest("thread/start")?.params as {
+			config?: Record<string, unknown>;
+		};
+
+		expect(params.config?.model_reasoning_effort).toBe("high");
+	});
+
 	it("serializes a workspace-mode sandbox to thread/start sandbox + config", async () => {
 		const { backend, client } = makeBackend();
 		await backend.open({

--- a/packages/codex-runner/test/CodexConfigBuilder.test.ts
+++ b/packages/codex-runner/test/CodexConfigBuilder.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { CodexConfigBuilder } from "../src/config/CodexConfigBuilder.js";
+import type { CodexRunnerConfig } from "../src/types.js";
+
+function makeConfig(
+	overrides: Partial<CodexRunnerConfig> = {},
+): CodexRunnerConfig {
+	return {
+		model: "gpt-5.6-luna",
+		workingDirectory: "/tmp/cyrus-codex-config-test",
+		cyrusHome: "/tmp/cyrus-codex-config-test-home",
+		...overrides,
+	} as CodexRunnerConfig;
+}
+
+describe("CodexConfigBuilder reasoning effort", () => {
+	it("defaults to medium", async () => {
+		const resolved = await new CodexConfigBuilder(makeConfig()).build();
+
+		expect(resolved.modelReasoningEffort).toBe("medium");
+	});
+
+	it("preserves the selected effort", async () => {
+		const resolved = await new CodexConfigBuilder(
+			makeConfig({ modelReasoningEffort: "low" }),
+		).build();
+
+		expect(resolved.modelReasoningEffort).toBe("low");
+	});
+});

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -23,6 +23,10 @@ import { buildPrMarkerHook } from "./hooks/PrMarkerHook.js";
 import { appendBrowserUseAddendum } from "./prompts/browserUsePromptAddendum.js";
 import { appendCloudRuntimeAddendum } from "./prompts/cloudRuntimePromptAddendum.js";
 import { appendFailureModeAddendum } from "./prompts/failureModePromptAddendum.js";
+import {
+	isRecognizedGpt56Model,
+	type ReasoningEffort,
+} from "./RunnerSelectionService.js";
 
 /**
  * Subset of McpConfigService consumed by RunnerConfigBuilder.
@@ -59,6 +63,7 @@ export interface IRunnerSelector {
 		runnerType: RunnerType;
 		modelOverride?: string;
 		fallbackModelOverride?: string;
+		reasoningEffort?: ReasoningEffort;
 	};
 	getDefaultModelForRunner(runnerType: RunnerType): string;
 	getDefaultFallbackModelForRunner(runnerType: RunnerType): string;
@@ -329,14 +334,25 @@ export class RunnerConfigBuilder {
 		let runnerType = runnerSelection.runnerType;
 		let modelOverride = runnerSelection.modelOverride;
 		let fallbackModelOverride = runnerSelection.fallbackModelOverride;
+		const reasoningEffort = runnerSelection.reasoningEffort ?? "medium";
 
 		// If the labels have changed, and we are resuming a session. Use the existing runner for the session.
 		if (input.session.claudeSessionId && runnerType !== "claude") {
+			if (isRecognizedGpt56Model(modelOverride)) {
+				throw new Error(
+					`Cannot apply GPT-5.6 model "${modelOverride}" to an existing Claude session. Start a new Codex session instead.`,
+				);
+			}
 			runnerType = "claude";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("claude");
 			fallbackModelOverride =
 				this.runnerSelector.getDefaultFallbackModelForRunner("claude");
 		} else if (input.session.geminiSessionId && runnerType !== "gemini") {
+			if (isRecognizedGpt56Model(modelOverride)) {
+				throw new Error(
+					`Cannot apply GPT-5.6 model "${modelOverride}" to an existing Gemini session. Start a new Codex session instead.`,
+				);
+			}
 			runnerType = "gemini";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("gemini");
 			fallbackModelOverride =
@@ -347,6 +363,11 @@ export class RunnerConfigBuilder {
 			fallbackModelOverride =
 				this.runnerSelector.getDefaultFallbackModelForRunner("codex");
 		} else if (input.session.cursorSessionId && runnerType !== "cursor") {
+			if (isRecognizedGpt56Model(modelOverride)) {
+				throw new Error(
+					`Cannot apply GPT-5.6 model "${modelOverride}" to an existing Cursor session. Start a new Codex session instead.`,
+				);
+			}
 			runnerType = "cursor";
 			modelOverride = this.runnerSelector.getDefaultModelForRunner("cursor");
 			fallbackModelOverride =
@@ -419,6 +440,9 @@ export class RunnerConfigBuilder {
 				fallbackModelOverride ||
 				input.repository.fallbackModel ||
 				this.runnerSelector.getDefaultFallbackModelForRunner(runnerType),
+			...(runnerType === "codex" && {
+				modelReasoningEffort: reasoningEffort,
+			}),
 			logger: log,
 			hooks,
 			// Plugins providing managed skills.

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -1,5 +1,21 @@
 import type { EdgeWorkerConfig, RunnerType } from "cyrus-core";
 
+export type ReasoningEffort = "low" | "medium" | "high";
+
+/** Canonical GPT-5.6 labels. `gpt-5.6` is the documented Sol alias. */
+export const GPT56_MODEL_BY_LABEL = {
+	terra: "gpt-5.6-terra",
+	luna: "gpt-5.6-luna",
+	sol: "gpt-5.6-sol",
+	"gpt-5.6": "gpt-5.6-sol",
+} as const;
+
+const GPT56_MODEL_IDS = new Set<string>(Object.values(GPT56_MODEL_BY_LABEL));
+
+export function isRecognizedGpt56Model(model?: string): boolean {
+	return GPT56_MODEL_IDS.has(model?.toLowerCase() ?? "");
+}
+
 export class RunnerSelectionService {
 	private config: EdgeWorkerConfig;
 
@@ -118,7 +134,8 @@ export class RunnerSelectionService {
 	 *
 	 * Precedence:
 	 * 1. Description tags override labels
-	 * 2. Agent labels override model labels
+	 * 2. Agent labels override model labels, except a recognized GPT-5.6 label
+	 *    fails loudly instead of switching model families
 	 * 3. Model labels can infer agent type
 	 * 4. Defaults to claude runner
 	 */
@@ -129,6 +146,7 @@ export class RunnerSelectionService {
 		runnerType: RunnerType;
 		modelOverride?: string;
 		fallbackModelOverride?: string;
+		reasoningEffort: ReasoningEffort;
 	} {
 		const normalizedLabels = (labels || []).map((label) => label.toLowerCase());
 		const normalizedDescription = issueDescription || "";
@@ -156,6 +174,33 @@ export class RunnerSelectionService {
 
 		const isCodexModel = (model: string): boolean =>
 			/gpt-[a-z0-9.-]*codex$/i.test(model) || /^gpt-[a-z0-9.-]+$/i.test(model);
+
+		const resolveGpt56Model = (model?: string): string | undefined => {
+			if (!model) return undefined;
+			return GPT56_MODEL_BY_LABEL[
+				model.toLowerCase() as keyof typeof GPT56_MODEL_BY_LABEL
+			];
+		};
+
+		const resolveReasoningEffort = (
+			lowercaseLabels: string[],
+		): ReasoningEffort => {
+			const efforts = lowercaseLabels
+				.map((label) =>
+					label.startsWith("effort:") ? label.slice("effort:".length) : label,
+				)
+				.filter(
+					(effort): effort is ReasoningEffort =>
+						effort === "low" || effort === "medium" || effort === "high",
+				);
+			const uniqueEfforts = [...new Set(efforts)];
+			if (uniqueEfforts.length > 1) {
+				throw new Error(
+					`Conflicting reasoning effort labels: ${uniqueEfforts.join(", ")}. Remove all but one before dispatching.`,
+				);
+			}
+			return uniqueEfforts[0] ?? "medium";
+		};
 
 		const inferRunnerFromModel = (model?: string): RunnerType | undefined => {
 			if (!model) return undefined;
@@ -239,6 +284,12 @@ export class RunnerSelectionService {
 		const resolveModelFromLabel = (
 			lowercaseLabels: string[],
 		): string | undefined => {
+			for (const label of Object.keys(GPT56_MODEL_BY_LABEL)) {
+				if (lowercaseLabels.includes(label)) {
+					return resolveGpt56Model(label);
+				}
+			}
+
 			const codexModelLabel = lowercaseLabels.find((label) =>
 				isCodexModel(label),
 			);
@@ -287,9 +338,11 @@ export class RunnerSelectionService {
 							: undefined;
 		const resolvedAgentFromLabels = resolveAgentFromLabel(normalizedLabels);
 
-		const modelFromDescription = descriptionModelTagRaw;
+		const modelFromDescription =
+			resolveGpt56Model(descriptionModelTagRaw) || descriptionModelTagRaw;
 		const modelFromLabels = resolveModelFromLabel(normalizedLabels);
 		const explicitModel = modelFromDescription || modelFromLabels;
+		const reasoningEffort = resolveReasoningEffort(normalizedLabels);
 
 		const runnerType: RunnerType =
 			resolvedAgentFromDescription ||
@@ -301,6 +354,11 @@ export class RunnerSelectionService {
 		const modelRunner = inferRunnerFromModel(explicitModel);
 		let modelOverride = explicitModel;
 		if (modelOverride && modelRunner && modelRunner !== runnerType) {
+			if (isRecognizedGpt56Model(modelOverride)) {
+				throw new Error(
+					`GPT-5.6 model "${modelOverride}" requires the codex runner, but "${runnerType}" was selected. Remove the conflicting runner selector before dispatching.`,
+				);
+			}
 			modelOverride = undefined;
 		}
 
@@ -321,6 +379,7 @@ export class RunnerSelectionService {
 			runnerType,
 			modelOverride: resolvedModelOverride,
 			fallbackModelOverride,
+			reasoningEffort,
 		};
 	}
 }

--- a/packages/edge-worker/src/RunnerSelectionService.ts
+++ b/packages/edge-worker/src/RunnerSelectionService.ts
@@ -343,6 +343,16 @@ export class RunnerSelectionService {
 		const modelFromLabels = resolveModelFromLabel(normalizedLabels);
 		const explicitModel = modelFromDescription || modelFromLabels;
 		const reasoningEffort = resolveReasoningEffort(normalizedLabels);
+		const unknownModelLabels = normalizedLabels.filter((label) => {
+			if (!/^(?:gpt|claude|gemini)(?:[-.:]|$)/.test(label)) return false;
+			if (isCodexModel(label)) return false;
+			return label !== "claude" && label !== "gemini";
+		});
+		if (unknownModelLabels.length > 0) {
+			console.warn(
+				`[RunnerSelectionService] Unknown model label(s): ${unknownModelLabels.join(", ")}; using the normal runner fallback.`,
+			);
+		}
 
 		const runnerType: RunnerType =
 			resolvedAgentFromDescription ||

--- a/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.codex-skills.test.ts
@@ -7,6 +7,8 @@ import {
 	RunnerConfigBuilder,
 } from "../src/RunnerConfigBuilder.js";
 
+type RunnerSelection = ReturnType<IRunnerSelector["determineRunnerSelection"]>;
+
 const silentLogger: ILogger = {
 	debug: () => {},
 	info: () => {},
@@ -14,7 +16,9 @@ const silentLogger: ILogger = {
 	error: () => {},
 } as unknown as ILogger;
 
-function makeBuilder(): RunnerConfigBuilder {
+function makeBuilder(
+	selection: RunnerSelection = { runnerType: "codex" },
+): RunnerConfigBuilder {
 	const chatToolResolver: IChatToolResolver = {
 		buildChatAllowedTools: () => ["Read(**)"],
 	};
@@ -23,7 +27,7 @@ function makeBuilder(): RunnerConfigBuilder {
 		buildMergedMcpConfigPath: () => undefined,
 	};
 	const runnerSelector: IRunnerSelector = {
-		determineRunnerSelection: () => ({ runnerType: "codex" as const }),
+		determineRunnerSelection: () => selection,
 		getDefaultModelForRunner: () => "gpt-5.5",
 		getDefaultFallbackModelForRunner: () => "gpt-5.2-codex",
 	};
@@ -74,5 +78,47 @@ describe("RunnerConfigBuilder Codex managed skills", () => {
 		expect(config.plugins).toEqual(plugins);
 		expect(config.skills).toEqual(["custom-user"]);
 		expect(config.codexHome).toBeUndefined();
+	});
+
+	it("passes GPT-5.6 model and reasoning effort into the Codex config", () => {
+		const session = {
+			issueId: "issue-1",
+			issue: { identifier: "ABC-1" },
+			workspace: { path: "/ws/repo-a", isGitWorktree: true },
+		} as unknown as CyrusAgentSession;
+		const repository = {
+			id: "repo-a",
+			name: "Repo A",
+			repositoryPath: "/repos/repo-a",
+			allowedTools: [],
+		} as unknown as RepositoryConfig;
+
+		const { config, runnerType } = makeBuilder({
+			runnerType: "codex",
+			modelOverride: "gpt-5.6-luna",
+			fallbackModelOverride: "gpt-5.2-codex",
+			reasoningEffort: "high",
+		}).buildIssueConfig({
+			session,
+			repository,
+			sessionId: "sess-1",
+			systemPrompt: "test",
+			allowedTools: ["Read(**)"],
+			allowedDirectories: ["/repos/repo-a"],
+			disallowedTools: [],
+			cyrusHome: "/tmp/cyrus-home",
+			linearWorkspaceId: "ws-1",
+			logger: silentLogger,
+			onMessage: () => {},
+			onError: () => {},
+			requireLinearWorkspaceId: () => "ws-1",
+		});
+
+		expect(runnerType).toBe("codex");
+		expect(config.model).toBe("gpt-5.6-luna");
+		expect((config as Record<string, unknown>).modelReasoningEffort).toBe(
+			"high",
+		);
+		expect(config.model).not.toBe("sonnet");
 	});
 });

--- a/packages/edge-worker/test/RunnerSelectionService.test.ts
+++ b/packages/edge-worker/test/RunnerSelectionService.test.ts
@@ -1,5 +1,5 @@
 import type { EdgeWorkerConfig } from "cyrus-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	GPT56_MODEL_BY_LABEL,
 	RunnerSelectionService,
@@ -48,5 +48,20 @@ describe("RunnerSelectionService GPT-5.6 model routing", () => {
 		expect(() =>
 			makeService().determineRunnerSelection(["luna", "claude"]),
 		).toThrow(/requires the codex runner/);
+	});
+
+	it("logs an unknown model-family label before falling back", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const selection = makeService().determineRunnerSelection([
+			"claude-made-up",
+		]);
+
+		expect(selection.runnerType).toBe("claude");
+		expect(warn).toHaveBeenCalledWith(
+			expect.stringContaining("Unknown model label(s): claude-made-up"),
+		);
+
+		warn.mockRestore();
 	});
 });

--- a/packages/edge-worker/test/RunnerSelectionService.test.ts
+++ b/packages/edge-worker/test/RunnerSelectionService.test.ts
@@ -1,0 +1,52 @@
+import type { EdgeWorkerConfig } from "cyrus-core";
+import { describe, expect, it } from "vitest";
+import {
+	GPT56_MODEL_BY_LABEL,
+	RunnerSelectionService,
+} from "../src/RunnerSelectionService.js";
+
+function makeService(): RunnerSelectionService {
+	return new RunnerSelectionService({
+		defaultRunner: "claude",
+	} as EdgeWorkerConfig);
+}
+
+describe("RunnerSelectionService GPT-5.6 model routing", () => {
+	it.each([
+		["terra", GPT56_MODEL_BY_LABEL.terra],
+		["luna", GPT56_MODEL_BY_LABEL.luna],
+		["sol", GPT56_MODEL_BY_LABEL.sol],
+		["gpt-5.6", GPT56_MODEL_BY_LABEL["gpt-5.6"]],
+	] as const)("routes %s to the Codex runner as %s", (label, model) => {
+		const selection = makeService().determineRunnerSelection([label]);
+
+		expect(selection.runnerType).toBe("codex");
+		expect(selection.modelOverride).toBe(model);
+		expect(selection.modelOverride).not.toMatch(/^sonnet$/);
+		expect(selection.fallbackModelOverride).not.toMatch(/^sonnet$/);
+	});
+
+	it.each([
+		["low", "low"],
+		["effort:medium", "medium"],
+		["high", "high"],
+	] as const)("accepts %s as reasoning effort %s", (label, effort) => {
+		const selection = makeService().determineRunnerSelection(["luna", label]);
+
+		expect(selection.runnerType).toBe("codex");
+		expect(selection.modelOverride).toBe("gpt-5.6-luna");
+		expect(selection.reasoningEffort).toBe(effort);
+	});
+
+	it("defaults reasoning effort to medium", () => {
+		expect(
+			makeService().determineRunnerSelection(["luna"]).reasoningEffort,
+		).toBe("medium");
+	});
+
+	it("rejects a recognized GPT label when a Claude runner is explicitly selected", () => {
+		expect(() =>
+			makeService().determineRunnerSelection(["luna", "claude"]),
+		).toThrow(/requires the codex runner/);
+	});
+});

--- a/packages/edge-worker/test/RunnerSelectionService.test.ts
+++ b/packages/edge-worker/test/RunnerSelectionService.test.ts
@@ -38,6 +38,22 @@ describe("RunnerSelectionService GPT-5.6 model routing", () => {
 		expect(selection.reasoningEffort).toBe(effort);
 	});
 
+	it("maps a GPT-5.6 name in a [model=...] description tag", () => {
+		const selection = makeService().determineRunnerSelection(
+			[],
+			"Please look into this. [model=terra]",
+		);
+
+		expect(selection.runnerType).toBe("codex");
+		expect(selection.modelOverride).toBe(GPT56_MODEL_BY_LABEL.terra);
+	});
+
+	it("rejects conflicting reasoning effort labels", () => {
+		expect(() =>
+			makeService().determineRunnerSelection(["luna", "low", "high"]),
+		).toThrow(/Conflicting reasoning effort labels/);
+	});
+
 	it("defaults reasoning effort to medium", () => {
 		expect(
 			makeService().determineRunnerSelection(["luna"]).reasoningEffort,


### PR DESCRIPTION
## What changed

- Map the `terra`, `luna`, `sol`, and bare `gpt-5.6` labels to the requested GPT-5.6 model IDs and select the Codex runner. The same names work as a `[model=...]` description tag, which takes precedence over labels.
- Carry bare or `effort:`-prefixed `low`/`medium`/`high` labels through runner config, defaulting to `medium`.
- Serialize the selected effort into the Codex app-server config so it reaches OpenAI as `reasoning.effort`.
- Fail loudly for recognized GPT-5.6 labels that conflict with a Claude-family selector or an existing non-Codex session, and for conflicting reasoning-effort labels.
- Log unknown model-family-shaped labels before applying the normal fallback.

## Root cause

`RunnerSelectionService` only recognized `gpt-*` model labels. `terra`/`luna`/`sol` therefore selected the default Claude runner, and the existing Codex `modelReasoningEffort` field was never serialized by `AppServerCodexBackend`.

## Review feedback addressed

@Connoropolous asked that the default reasoning-effort change and the label-based override documentation land in the changelog. Both are now written out explicitly:

- **`### Changed`** — Codex sessions now default to `medium`. Previously any `gpt-5*` model was pinned to `high` and every other Codex model inherited the Codex CLI default, so effort was neither predictable nor adjustable per issue.
- **`### Changed`** — how to override it: label the issue `low`, `medium`, or `high` (or the prefixed `effort:low` / `effort:medium` / `effort:high` forms); the chosen effort reaches OpenAI as `reasoning.effort`; two conflicting effort labels stop the run with an explicit error.
- **`### Fixed`** — how the model labels map through the Codex runtime: `terra`/`luna`/`sol`/`gpt-5.6` → `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.6-sol`, description-tag precedence, and the explicit errors on runner conflicts.

Two tests were added to back the newly documented behavior: the `[model=terra]` description-tag mapping and the conflicting-effort-label error.

## Relationship to #1372

#1372 bumped the bundled Codex runtime/SDK to `0.144.4` (the minimum release that serves GPT-5.6 models) and added a version guard test. It does not supersede this PR — it ships the runtime, this PR ships the routing that reaches it. This branch is rebased on top of it.

## Validation

Rebased onto `main` at `3241bdd9`; the only conflict was `CHANGELOG.md` (`## [Unreleased]` section), resolved onto main's current entries.

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` — exit 0; the 11 warnings are pre-existing and in files this PR does not touch
- `pnpm test:packages:run` — all package tests green; EdgeWorker 66 files / 762 tests, Codex 13 files / 72 tests
- `pnpm --filter './apps/*' test:run` — CLI 6 files / 102 tests; F1 no-test pass
- `git diff --check` clean

Linear: BYE-340
