### PR TITLE
Drop unbacked "organization" event from GitHub App manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The self-hosted GitHub App setup flow (`cyrus-setup-github` skill, "enable @mentions") no longer fails with "Default events are not supported by permissions: organization". The generated App manifest subscribed to an event with no matching permission, so GitHub rejected the submission and no App was ever created. ([#1406](https://github.com/cyrusagents/cyrus/issues/1406), [#1407](https://github.com/cyrusagents/cyrus/pull/1407))
+
 ### Security
 - Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` reports no known vulnerabilities. ([CYPACK-1431](https://linear.app/ceedar/issue/CYPACK-1431/address-open-security-patches-for-cyrus-cli), [#1404](https://github.com/cyrusagents/cyrus/pull/1404))
 

--- a/skills/cyrus-setup-github/SKILL.md
+++ b/skills/cyrus-setup-github/SKILL.md
@@ -161,7 +161,6 @@ Construct the manifest, substituting `AGENT_NAME`, `HOMEPAGE_URL`, and `CYRUS_BA
   },
   "default_events": [
     "issue_comment",
-    "organization",
     "pull_request_review",
     "pull_request_review_comment",
     "repository"


### PR DESCRIPTION
## Summary
- The `cyrus-setup-github` skill's App manifest subscribed to the `organization` webhook event without a matching `organization_administration` permission. GitHub's manifest API rejects the entire manifest if any event lacks a backing permission, so the "enable @mentions" self-hosted setup flow failed outright with no App created.
- `organization` was added in #1265 to support org rename/transfer auto-fix, but that consumer lives only in cyrus-hosted (a separate, closed-source repo) — this repo has no handler for the event, so it provided no benefit to self-hosted users.
- Fix: drop `organization` from `default_events` instead of adding the permission, since nothing here consumes it.

## Test plan
- [x] Confirmed no code in `packages/edge-worker` or `packages/github-event-transport` handles a GitHub `organization` webhook event (only the hosted product does).
- [ ] Manually regenerate the manifest via the `cyrus-setup-github` skill and submit it to GitHub's App creation flow to confirm it's accepted.

Fixes #1406

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoKW92DuSu2asnc31eyg7n)_