### PR TITLE
Improve contributor guidance and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,15 @@
 ## Summary
 
-<!-- Explain what changed and why. -->
+<!-- What changed and why? -->
 
 ## Related issue
 
-<!-- Link the relevant GitHub issue or Linear ticket. -->
+<!-- Link the GitHub issue or Linear ticket, if there is one. -->
 
 ## Verification
 
-<!-- List the commands and manual checks you ran. -->
+<!-- How did you test the change? -->
 
-- [ ] Tests were added or updated where needed
-- [ ] Relevant tests, lint and type checking pass
-
-## Checklist
-
-- [ ] The change is focused and follows existing patterns
-- [ ] Documentation and changelogs are updated where needed
+- [ ] I added or updated tests where needed
+- [ ] I ran relevant tests, lint and type checking
+- [ ] I updated documentation and changelogs where needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- Explain what changed and why. -->
+
+## Related issue
+
+<!-- Link the relevant GitHub issue or Linear ticket. -->
+
+## Verification
+
+<!-- List the commands and manual checks you ran. -->
+
+- [ ] Tests were added or updated where needed
+- [ ] Relevant tests, lint and type checking pass
+
+## Checklist
+
+- [ ] The change is focused and follows existing patterns
+- [ ] Documentation and changelogs are updated where needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,22 @@
 ## Summary
 
-<!-- What changed and why? -->
+<!-- What does this PR change, and why? -->
 
 ## Related issue
 
-<!-- Link the GitHub issue or Linear ticket, if there is one. -->
+<!-- Optional. Link a GitHub issue (for example, "Fixes #123"). Remove this section if there isn't one. -->
+
+## Approach and design decisions
+
+<!-- Explain significant choices, tradeoffs or, for a bug fix, the root cause. Remove this section if the change is straightforward. -->
 
 ## Verification
 
-<!-- List the tests, checks or manual steps you ran. -->
+<!-- List the tests you added or updated and the automated or manual validation you performed. -->
+
+## Checklist
+
+- [ ] I added or updated tests for behavior changes, or explained why tests are not needed
+- [ ] I listed the relevant automated and manual validation above
+- [ ] I updated documentation and changelogs where needed
+- [ ] I kept this PR focused and called out any compatibility, security or operational impact

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,4 @@
 
 ## Verification
 
-<!-- How did you test the change? -->
-
-- [ ] I added or updated tests where needed
-- [ ] I ran relevant tests, lint and type checking
-- [ ] I updated documentation and changelogs where needed
+<!-- List the tests, checks or manual steps you ran. -->

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Changed
+- Improved contributor guidance, added a reusable pull request template, and linked the contribution process from the README. ([CYPACK-1444](https://linear.app/ceedar/issue/CYPACK-1444/update-contributingmd-and-create-a-contributor-pull-request-template), [#1410](https://github.com/cyrusagents/cyrus/pull/1410))
+
 ## [0.2.68] - 2026-08-05
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,94 +1,131 @@
 # Contributing to Cyrus
 
-Cyrus connects AI coding agents to Linear, GitHub, GitLab and Slack, then manages the issue-to-pull-request workflow in isolated Git worktrees. Contributions that make those workflows more reliable, easier to operate or better documented are welcome.
+We love your input! We want to make contributing to Cyrus as easy and transparent as possible, whether it's:
 
-You can help by reporting bugs, improving documentation, proposing features or submitting fixes.
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
 
-## Before You Start
+Cyrus connects AI coding agents to Linear, GitHub, GitLab and Slack, and turns assigned work into reviewed changes in isolated Git worktrees.
 
-- Search the existing issues and pull requests before opening a new one.
-- Open an issue for a bug or focused improvement. For larger changes, discuss the approach with the maintainers before investing significant time.
-- Keep each pull request focused on one problem. Small, reviewable changes are easier to test and merge.
+## Prerequisites
 
-## Development Setup
+- **Node.js** >= 22
+- **pnpm** >= 10 (this is a pnpm monorepo — do not use npm or yarn)
 
-### Prerequisites
+## Development Process
 
-- **Node.js** 22 or later
-- **pnpm** 10 or later (this is a pnpm monorepo; do not use npm or Yarn)
+We use GitHub for issue tracking, code hosting and pull requests. We also track issues on an internal Linear workspace.
 
-### Get Started
+Before starting a larger change, open an issue so we can discuss the approach together.
 
-1. Fork the repository and create a branch from `main`.
+### Getting Started
+
+1. Fork the repo and create your branch from `main`
 2. Install dependencies:
-
    ```bash
    pnpm install
    ```
-
-3. Build the workspace:
-
+3. Build all packages:
    ```bash
    pnpm build
    ```
-
-4. Run the package tests:
-
+4. Run the tests:
    ```bash
    pnpm test:packages:run
    ```
-
-5. Start packages in development mode when you need watch processes:
-
+5. Start development mode (watch all packages):
    ```bash
    pnpm dev
    ```
 
-## Repository Structure
+### Project Structure
 
-Cyrus is a TypeScript pnpm monorepo:
+Cyrus is a pnpm monorepo with the following layout:
 
-```text
+```
 cyrus/
 ├── apps/
-│   ├── cli/       # The cyrus-ai CLI
-│   └── f1/        # End-to-end test-drive framework
+│   ├── cli/        # Main CLI application (the `cyrus-ai` npm package)
+│   └── f1/         # F1 testing framework for end-to-end test drives
 └── packages/
-    ├── core/      # Shared configuration, types and session management
-    ├── edge-worker/ # Issue routing and agent orchestration
-    ├── *-runner/  # Agent runtime adapters
-    └── *-transport/ # Linear, GitHub, GitLab and Slack event transports
+    ├── core/                     # Shared types and session management
+    ├── edge-worker/              # Edge worker implementation
+    ├── claude-runner/            # Claude CLI execution wrapper
+    ├── codex-runner/             # Codex CLI execution wrapper
+    ├── cursor-runner/            # Cursor CLI execution wrapper
+    ├── gemini-runner/            # Gemini CLI execution wrapper
+    ├── simple-agent-runner/      # Simple agent runner
+    ├── config-updater/           # Configuration update utilities
+    ├── cloudflare-tunnel-client/ # Cloudflare tunnel management
+    ├── mcp-tools/                # MCP tool definitions
+    ├── linear-event-transport/   # Linear webhook event handling
+    ├── github-event-transport/   # GitHub event handling
+    ├── gitlab-event-transport/   # GitLab event handling
+    └── slack-event-transport/    # Slack event handling
 ```
-
-Package-level README files contain more detail about individual components.
-
-## Contribution Standards
-
-- Write TypeScript and follow the structure and naming of the surrounding code.
-- Add or update tests when behavior changes. We use [Vitest](https://vitest.dev/) across the packages.
-- Keep public behavior, configuration and setup documentation in sync with the code.
-- Use Biome for linting and formatting. Husky and lint-staged also run checks when you commit.
-- Avoid unrelated refactors in the same pull request.
-
-Before submitting, run the checks relevant to your change. For most changes, run the full verification set:
-
-```bash
-pnpm test:packages:run
-pnpm typecheck
-pnpm lint
-```
-
-Use `pnpm format` to apply the repository's formatting rules.
 
 ## Pull Requests
 
-1. Rebase or merge the latest `main` into your branch.
-2. Confirm that tests, type checking and linting pass.
-3. Update documentation when setup, configuration or user-visible behavior changes.
-4. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for user-visible changes, or `CHANGELOG.internal.md` for internal-only changes. Follow the existing format and include the related issue and pull request links when available.
-5. Complete the repository's [pull request template](./.github/PULL_REQUEST_TEMPLATE.md). Explain what changed and why, link the related issue and list the verification you performed.
+1. Create your branch from `main`
+2. Write and run tests for any new code
+3. Run the verification suite before submitting:
+   ```bash
+   pnpm test:packages:run   # Run all package tests
+   pnpm typecheck           # TypeScript type checking
+   pnpm lint                # Biome lint check
+   ```
+4. Update `CHANGELOG.md` under the `## [Unreleased]` section with your changes:
+   - Use subsections: `### Added`, `### Changed`, `### Fixed`, `### Removed`
+   - Include the PR number/link and Linear issue identifier when available
+   - Focus on end-user impact, not implementation details
+   - For internal-only changes, update `CHANGELOG.internal.md` instead
+5. Fill out the [pull request template](./.github/PULL_REQUEST_TEMPLATE.md) and issue your pull request
 
-Maintainers may ask for changes or additional verification. Review feedback is part of the process, and we appreciate follow-up commits that keep the discussion easy to trace.
+## Testing
+
+We use [Vitest](https://vitest.dev/) for all packages.
+
+```bash
+# Run all package tests (once)
+pnpm test:packages:run
+
+# Run all tests in watch mode
+pnpm test
+
+# Run tests for a specific package
+cd packages/edge-worker
+pnpm test:run
+
+# Run a specific test file
+cd packages/edge-worker
+pnpm test:run -- path/to/test.ts
+```
+
+## Code Style
+
+- **TypeScript** for all packages — no plain JavaScript
+- **Biome** for linting and formatting (configured in the repo root)
+- **Husky** + **lint-staged** run automatically on commit to enforce formatting
+- Follow the existing code structure and organization
+- Format code before committing:
+  ```bash
+  pnpm format
+  ```
+
+## Common Commands
+
+```bash
+pnpm install              # Install all dependencies
+pnpm build                # Build all packages
+pnpm dev                  # Development mode (watch all packages)
+pnpm test                 # Run tests across all packages (watch mode)
+pnpm test:packages:run    # Run package tests once (recommended for CI)
+pnpm typecheck            # TypeScript type checking
+pnpm lint                 # Biome lint check
+pnpm format               # Auto-format with Biome
+```
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,126 +1,94 @@
 # Contributing to Cyrus
 
-We love your input! We want to make contributing to Cyrus as easy and transparent as possible, whether it's:
+Cyrus connects AI coding agents to Linear, GitHub, GitLab and Slack, then manages the issue-to-pull-request workflow in isolated Git worktrees. Contributions that make those workflows more reliable, easier to operate or better documented are welcome.
 
-- Reporting a bug
-- Discussing the current state of the code
-- Submitting a fix
-- Proposing new features
+You can help by reporting bugs, improving documentation, proposing features or submitting fixes.
 
-## Prerequisites
+## Before You Start
 
-- **Node.js** >= 22
-- **pnpm** >= 10 (this is a pnpm monorepo — do not use npm or yarn)
+- Search the existing issues and pull requests before opening a new one.
+- Open an issue for a bug or focused improvement. For larger changes, discuss the approach with the maintainers before investing significant time.
+- Keep each pull request focused on one problem. Small, reviewable changes are easier to test and merge.
 
-## Development Process
+## Development Setup
 
-We use GitHub for issue tracking, code hosting and pull requests. We also track issues on an internal Linear workspace.
+### Prerequisites
 
-### Getting Started
+- **Node.js** 22 or later
+- **pnpm** 10 or later (this is a pnpm monorepo; do not use npm or Yarn)
 
-1. Fork the repo and create your branch from `main`
+### Get Started
+
+1. Fork the repository and create a branch from `main`.
 2. Install dependencies:
+
    ```bash
    pnpm install
    ```
-3. Build all packages:
+
+3. Build the workspace:
+
    ```bash
    pnpm build
    ```
-4. Run the tests:
+
+4. Run the package tests:
+
    ```bash
    pnpm test:packages:run
    ```
-5. Start development mode (watch all packages):
+
+5. Start packages in development mode when you need watch processes:
+
    ```bash
    pnpm dev
    ```
 
-### Project Structure
+## Repository Structure
 
-Cyrus is a pnpm monorepo with the following layout:
+Cyrus is a TypeScript pnpm monorepo:
 
-```
+```text
 cyrus/
 ├── apps/
-│   ├── cli/        # Main CLI application (the `cyrus-ai` npm package)
-│   └── f1/         # F1 testing framework for end-to-end test drives
+│   ├── cli/       # The cyrus-ai CLI
+│   └── f1/        # End-to-end test-drive framework
 └── packages/
-    ├── core/                     # Shared types and session management
-    ├── edge-worker/              # Edge worker implementation
-    ├── claude-runner/            # Claude CLI execution wrapper
-    ├── codex-runner/             # Codex CLI execution wrapper
-    ├── cursor-runner/            # Cursor CLI execution wrapper
-    ├── gemini-runner/            # Gemini CLI execution wrapper
-    ├── simple-agent-runner/      # Simple agent runner
-    ├── config-updater/           # Configuration update utilities
-    ├── cloudflare-tunnel-client/ # Cloudflare tunnel management
-    ├── mcp-tools/                # MCP tool definitions
-    ├── linear-event-transport/   # Linear webhook event handling
-    ├── github-event-transport/   # GitHub event handling
-    └── slack-event-transport/    # Slack event handling
+    ├── core/      # Shared configuration, types and session management
+    ├── edge-worker/ # Issue routing and agent orchestration
+    ├── *-runner/  # Agent runtime adapters
+    └── *-transport/ # Linear, GitHub, GitLab and Slack event transports
 ```
+
+Package-level README files contain more detail about individual components.
+
+## Contribution Standards
+
+- Write TypeScript and follow the structure and naming of the surrounding code.
+- Add or update tests when behavior changes. We use [Vitest](https://vitest.dev/) across the packages.
+- Keep public behavior, configuration and setup documentation in sync with the code.
+- Use Biome for linting and formatting. Husky and lint-staged also run checks when you commit.
+- Avoid unrelated refactors in the same pull request.
+
+Before submitting, run the checks relevant to your change. For most changes, run the full verification set:
+
+```bash
+pnpm test:packages:run
+pnpm typecheck
+pnpm lint
+```
+
+Use `pnpm format` to apply the repository's formatting rules.
 
 ## Pull Requests
 
-1. Create your branch from `main`
-2. Write and run tests for any new code
-3. Run the verification suite before submitting:
-   ```bash
-   pnpm test:packages:run   # Run all package tests
-   pnpm typecheck            # TypeScript type checking
-   pnpm lint                 # Biome lint check
-   ```
-4. Update `CHANGELOG.md` under the `## [Unreleased]` section with your changes:
-   - Use subsections: `### Added`, `### Changed`, `### Fixed`, `### Removed`
-   - Include the PR number/link and Linear issue identifier (e.g., `CYPACK-123`)
-   - Focus on end-user impact, not implementation details
-   - For internal-only changes, update `CHANGELOG.internal.md` instead
-5. Issue your pull request
+1. Rebase or merge the latest `main` into your branch.
+2. Confirm that tests, type checking and linting pass.
+3. Update documentation when setup, configuration or user-visible behavior changes.
+4. Add an entry under `## [Unreleased]` in `CHANGELOG.md` for user-visible changes, or `CHANGELOG.internal.md` for internal-only changes. Follow the existing format and include the related issue and pull request links when available.
+5. Complete the repository's [pull request template](./.github/PULL_REQUEST_TEMPLATE.md). Explain what changed and why, link the related issue and list the verification you performed.
 
-## Testing
-
-We use [Vitest](https://vitest.dev/) for all packages.
-
-```bash
-# Run all package tests (once)
-pnpm test:packages:run
-
-# Run all tests in watch mode
-pnpm test
-
-# Run tests for a specific package
-cd packages/edge-worker
-pnpm test:run
-
-# Run a specific test file
-cd packages/edge-worker
-pnpm test:run -- path/to/test.ts
-```
-
-## Code Style
-
-- **TypeScript** for all packages — no plain JavaScript
-- **Biome** for linting and formatting (configured in the repo root)
-- **Husky** + **lint-staged** run automatically on commit to enforce formatting
-- Follow the existing code structure and organization
-- Format code before committing:
-  ```bash
-  pnpm format
-  ```
-
-## Common Commands
-
-```bash
-pnpm install              # Install all dependencies
-pnpm build                # Build all packages
-pnpm dev                  # Development mode (watch all packages)
-pnpm test                 # Run tests across all packages (watch mode)
-pnpm test:packages:run    # Run package tests once (recommended for CI)
-pnpm typecheck            # TypeScript type checking
-pnpm lint                 # Biome lint check
-pnpm format               # Auto-format with Biome
-```
+Maintainers may ask for changes or additional verification. Review feedback is part of the process, and we appreciate follow-up commits that keep the discussion easy to trace.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Cyrus connects AI coding agents to Linear, GitHub, GitLab and Slack, and turns a
 
 ## Development Process
 
-We use GitHub for issue tracking, code hosting and pull requests. We also track issues on an internal Linear workspace.
+We use GitHub for issue tracking, code hosting and pull requests. Our team also uses Linear internally, but you do not need a Linear issue to contribute.
 
 Before starting a larger change, open an issue so we can discuss the approach together.
 
@@ -78,7 +78,7 @@ cyrus/
    ```
 4. Update `CHANGELOG.md` under the `## [Unreleased]` section with your changes:
    - Use subsections: `### Added`, `### Changed`, `### Fixed`, `### Removed`
-   - Include the PR number/link and Linear issue identifier when available
+   - Include the PR number/link and related GitHub issue when available
    - Focus on end-user impact, not implementation details
    - For internal-only changes, update `CHANGELOG.internal.md` instead
 5. Fill out the [pull request template](./.github/PULL_REQUEST_TEMPLATE.md) and issue your pull request

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ No installation required. Everything is managed through [app.atcyrus.com](https:
 
 ## Contributing
 
-We welcome bug fixes, documentation improvements and focused feature contributions. See the [contribution guide](./CONTRIBUTING.md) for development setup, project standards and the pull request process.
+We love your input! See the [contribution guide](./CONTRIBUTING.md) to get started.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ No installation required. Everything is managed through [app.atcyrus.com](https:
 
 ---
 
+## Contributing
+
+We welcome bug fixes, documentation improvements and focused feature contributions. See the [contribution guide](./CONTRIBUTING.md) for development setup, project standards and the pull request process.
+
+---
+
 ## License
 
 This project is licensed under the Apache 2.0 license - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Assignee: @pauravhp ([paurav](https://linear.app/ceedar/profiles/paurav))

## Summary

- Preserve the existing contributor guide's warm, welcoming voice and familiar structure while adding current Cyrus context and standards.
- Add a contributor template based on 24 recent Cyrus-authored PRs, covering summary, an optional GitHub issue, significant design decisions, verification evidence, and a concise checklist.
- Clarify that external contributors do not need an internal Linear issue.
- Add a matching README contribution section and record the change in the internal changelog.

## Verification

- Reviewed 24 recent Cyrus-authored PRs: 2 open, 8 closed, and 14 merged
- `pnpm build`
- `pnpm test:packages:run` — 1,609 passed, 1 skipped
- `pnpm typecheck`
- `pnpm lint` — passed with existing warnings
- `git diff --check`
- Verified all new repository-local links resolve

Linear: https://linear.app/ceedar/issue/CYPACK-1444/update-contributingmd-and-create-a-contributor-pull-request-template

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
