### PR TITLE
feat(cli): add CYRUS_SERVER_HOST to decouple bind address from CYRUS_HOST_EXTERNAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`CYRUS_SERVER_HOST` sets the address Cyrus listens on.** Leave it unset and the bind address is derived from `CYRUS_HOST_EXTERNAL` as before. Set it when a tunnel or reverse proxy on the same host fronts Cyrus: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` keeps the port off your public interfaces without switching webhook verification into proxy mode. A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at startup. ([#1408](https://github.com/cyrusagents/cyrus/issues/1408), [#1411](https://github.com/cyrusagents/cyrus/pull/1411))
+
 ## [0.2.69] - 2026-08-26
 
 ### Added

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -46,13 +46,12 @@ The interactive wizard will prompt you for:
 
 ### Environment Variables
 
-- `CYRUS_HOST_EXTERNAL` - Set to `true` when Cyrus is reachable from outside the machine, i.e. self-hosted with webhooks delivered directly rather than forwarded. Default: `false`
+- `CYRUS_HOST_EXTERNAL` - Set to `true` when Cyrus receives webhooks directly rather than through the proxy. Default: `false`
   - Use this when running in Docker containers or when you need external access to the webhook server
-  - Selects direct (signature-verified) webhook handling instead of proxied, and turns on webhook source-IP validation by default
-  - Also supplies the default bind address, which `CYRUS_SERVER_HOST` overrides: `0.0.0.0` (all interfaces) when `true`, `localhost` when `false` or unset
-- `CYRUS_SERVER_HOST` - Address the server binds to. Default: derived from `CYRUS_HOST_EXTERNAL` as above
-  - Set this when a tunnel or reverse proxy on the same host fronts Cyrus and nothing off-box needs to reach the port: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` binds loopback while keeping direct webhook verification and IP validation
-  - Do not turn `CYRUS_HOST_EXTERNAL` off to move the bind address - that also switches webhook verification mode and disables IP validation
-  - A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; without it Cyrus stays loopback-only and rejects the configuration at startup, since the port would otherwise be reachable from the network while webhooks are verified in proxy mode and source-IP validation is off by default
+  - Selects direct (signature-verified) webhook handling and turns on webhook source-IP validation by default
+  - Supplies the default bind address: `0.0.0.0` when `true`, `localhost` when `false` or unset
+- `CYRUS_SERVER_HOST` - Address the server binds to, overriding the default above. Default: unset
+  - Set this when a tunnel or reverse proxy on the same host fronts Cyrus: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` binds loopback without changing webhook verification
+  - A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at startup. See [Self-Hosting](../../docs/SELF_HOSTING.md#43-cyrus_server_host)
 - `LINEAR_ALLOWED_TOOLS` - Comma-separated list of tools allowed for Linear-triggered sessions. Overrides `linearAllowedTools` in `~/.cyrus/config.json` when set.
 - `DISALLOWED_TOOLS` - Comma-separated list of tools disallowed across all sessions. Overrides `defaultDisallowedTools` in `~/.cyrus/config.json` when set.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -52,6 +52,6 @@ The interactive wizard will prompt you for:
   - Supplies the default bind address: `0.0.0.0` when `true`, `localhost` when `false` or unset
 - `CYRUS_SERVER_HOST` - Address the server binds to, overriding the default above. Default: unset
   - Set this when a tunnel or reverse proxy on the same host fronts Cyrus: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` binds loopback without changing webhook verification
-  - A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at startup. See [Self-Hosting](../../docs/SELF_HOSTING.md#43-cyrus_server_host)
+  - A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at startup. See [Self-Hosting](../../docs/SELF_HOSTING.md#43-choosing-a-bind-address)
 - `LINEAR_ALLOWED_TOOLS` - Comma-separated list of tools allowed for Linear-triggered sessions. Overrides `linearAllowedTools` in `~/.cyrus/config.json` when set.
 - `DISALLOWED_TOOLS` - Comma-separated list of tools disallowed across all sessions. Overrides `defaultDisallowedTools` in `~/.cyrus/config.json` when set.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -48,7 +48,7 @@ The interactive wizard will prompt you for:
 
 - `CYRUS_HOST_EXTERNAL` - Set to `true` when Cyrus receives webhooks directly rather than through the proxy. Default: `false`
   - Use this when running in Docker containers or when you need external access to the webhook server
-  - Selects direct (signature-verified) webhook handling and turns on webhook source-IP validation by default
+  - Selects direct (signature-verified) GitHub and Slack webhook handling, and turns on webhook source-IP validation by default
   - Supplies the default bind address: `0.0.0.0` when `true`, `localhost` when `false` or unset
 - `CYRUS_SERVER_HOST` - Address the server binds to, overriding the default above. Default: unset
   - Set this when a tunnel or reverse proxy on the same host fronts Cyrus: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` binds loopback without changing webhook verification

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -46,9 +46,13 @@ The interactive wizard will prompt you for:
 
 ### Environment Variables
 
-- `CYRUS_HOST_EXTERNAL` - Set to `true` to allow external connections (listens on `0.0.0.0` instead of `localhost`). Default: `false`
+- `CYRUS_HOST_EXTERNAL` - Set to `true` when Cyrus is reachable from outside the machine, i.e. self-hosted with webhooks delivered directly rather than forwarded. Default: `false`
   - Use this when running in Docker containers or when you need external access to the webhook server
-  - When `true`: Server listens on `0.0.0.0` (all interfaces)
-  - When `false` or unset: Server listens on `localhost` (local access only)
+  - Selects direct (signature-verified) webhook handling instead of proxied, and turns on webhook source-IP validation by default
+  - Also supplies the default bind address, which `CYRUS_SERVER_HOST` overrides: `0.0.0.0` (all interfaces) when `true`, `localhost` when `false` or unset
+- `CYRUS_SERVER_HOST` - Address the server binds to. Default: derived from `CYRUS_HOST_EXTERNAL` as above
+  - Set this when a tunnel or reverse proxy on the same host fronts Cyrus and nothing off-box needs to reach the port: `CYRUS_SERVER_HOST=127.0.0.1` with `CYRUS_HOST_EXTERNAL=true` binds loopback while keeping direct webhook verification and IP validation
+  - Do not turn `CYRUS_HOST_EXTERNAL` off to move the bind address - that also switches webhook verification mode and disables IP validation
+  - A non-loopback address requires `CYRUS_HOST_EXTERNAL=true`; without it Cyrus stays loopback-only and rejects the configuration at startup, since the port would otherwise be reachable from the network while webhooks are verified in proxy mode and source-IP validation is off by default
 - `LINEAR_ALLOWED_TOOLS` - Comma-separated list of tools allowed for Linear-triggered sessions. Overrides `linearAllowedTools` in `~/.cyrus/config.json` when set.
 - `DISALLOWED_TOOLS` - Comma-separated list of tools disallowed across all sessions. Overrides `defaultDisallowedTools` in `~/.cyrus/config.json` when set.

--- a/apps/cli/src/commands/RefreshTokenCommand.test.ts
+++ b/apps/cli/src/commands/RefreshTokenCommand.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	mockCreateServer: vi.fn(),
+	mockOpen: vi.fn(),
+	mockAsk: vi.fn(),
+	mockFetch: vi.fn(),
+}));
+
+vi.mock("node:http", () => ({
+	default: { createServer: mocks.mockCreateServer },
+	createServer: mocks.mockCreateServer,
+}));
+
+vi.mock("open", () => ({
+	default: mocks.mockOpen,
+}));
+
+vi.mock("../ui/CLIPrompts.js", () => ({
+	CLIPrompts: { ask: mocks.mockAsk },
+}));
+
+// Import after mocks
+import { RefreshTokenCommand } from "./RefreshTokenCommand.js";
+
+/** Args of the single `server.listen(port, host, callback)` call. */
+type ListenCall = [number, string, () => void];
+
+const createMockApp = () => ({
+	cyrusHome: "/home/user/.cyrus",
+	config: {
+		exists: vi.fn().mockReturnValue(true),
+		load: vi.fn().mockReturnValue({
+			linearWorkspaces: {
+				"workspace-1": {
+					linearToken: "lin_oauth_old",
+					linearWorkspaceName: "Test Workspace",
+				},
+			},
+		}),
+		update: vi.fn(),
+	},
+	getProxyUrl: vi.fn().mockReturnValue("https://proxy.example.com"),
+	logger: {
+		info: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+		success: vi.fn(),
+		divider: vi.fn(),
+	},
+});
+
+describe("RefreshTokenCommand", () => {
+	let listenCalls: ListenCall[];
+	let command: RefreshTokenCommand;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		listenCalls = [];
+
+		for (const key of ["CYRUS_SERVER_HOST", "CYRUS_HOST_EXTERNAL"]) {
+			vi.stubEnv(key, undefined as unknown as string);
+		}
+
+		// Refresh the first (only) workspace, then hand the callback server a
+		// valid token so `execute` finishes instead of polling for two minutes.
+		mocks.mockAsk.mockResolvedValue("1");
+		mocks.mockOpen.mockResolvedValue(undefined);
+		mocks.mockFetch.mockResolvedValue({
+			json: async () => ({ data: { viewer: { id: "u1" } } }),
+		});
+		global.fetch = mocks.mockFetch as unknown as typeof fetch;
+
+		mocks.mockCreateServer.mockImplementation(
+			(handler: (req: unknown, res: unknown) => void) => ({
+				listen: (...args: ListenCall) => {
+					listenCalls.push(args);
+					handler(
+						{ url: "/callback?token=lin_oauth_new" },
+						{ writeHead: vi.fn(), end: vi.fn() },
+					);
+					args[2]();
+				},
+				close: vi.fn(),
+			}),
+		);
+
+		command = new RefreshTokenCommand(createMockApp() as any);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+	});
+
+	it("binds the OAuth callback listener to localhost", async () => {
+		await command.execute([]);
+
+		expect(listenCalls).toHaveLength(1);
+		expect(listenCalls[0][1]).toBe("localhost");
+	});
+
+	it("ignores CYRUS_SERVER_HOST, whose callback URL is not this one", async () => {
+		vi.stubEnv("CYRUS_SERVER_HOST", "0.0.0.0");
+
+		await command.execute([]);
+
+		expect(listenCalls[0][1]).toBe("localhost");
+	});
+
+	it("stays on localhost even with CYRUS_HOST_EXTERNAL=true", async () => {
+		vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+		vi.stubEnv("CYRUS_SERVER_HOST", "192.168.1.10");
+
+		await command.execute([]);
+
+		expect(listenCalls[0][1]).toBe("localhost");
+	});
+});

--- a/apps/cli/src/commands/RefreshTokenCommand.ts
+++ b/apps/cli/src/commands/RefreshTokenCommand.ts
@@ -158,10 +158,8 @@ export class RefreshTokenCommand extends BaseCommand {
 						res.end("Not found");
 					}
 				});
-				// Always bind loopback: the callback URL is hardcoded to localhost
-				// below, so the listener never needs to be reachable off-box.
-				// Inheriting CYRUS_SERVER_HOST here would put the token-receiving
-				// callback on the network for no reason.
+				// The callback URL is always local, so this listener must not inherit
+				// the webhook listener's CYRUS_SERVER_HOST.
 				s.listen(serverPort, "localhost", () => {
 					console.log("Waiting for OAuth callback...");
 					resolve(s);

--- a/apps/cli/src/commands/RefreshTokenCommand.ts
+++ b/apps/cli/src/commands/RefreshTokenCommand.ts
@@ -158,7 +158,11 @@ export class RefreshTokenCommand extends BaseCommand {
 						res.end("Not found");
 					}
 				});
-				s.listen(serverPort, () => {
+				// Always bind loopback: the callback URL is hardcoded to localhost
+				// below, so the listener never needs to be reachable off-box.
+				// Inheriting CYRUS_SERVER_HOST here would put the token-receiving
+				// callback on the network for no reason.
+				s.listen(serverPort, "localhost", () => {
 					console.log("Waiting for OAuth callback...");
 					resolve(s);
 				});

--- a/apps/cli/src/commands/SelfAuthCommand.test.ts
+++ b/apps/cli/src/commands/SelfAuthCommand.test.ts
@@ -97,6 +97,8 @@ describe("SelfAuthCommand", () => {
 
 		// Ensure environment-dependent code paths are deterministic
 		delete process.env.CLOUDFLARE_TOKEN;
+		delete process.env.CYRUS_HOST_EXTERNAL;
+		delete process.env.CYRUS_SERVER_HOST;
 
 		// Reset Fastify mock instance
 		mocks.mockFastifyInstance.get.mockReset();
@@ -223,6 +225,73 @@ describe("SelfAuthCommand", () => {
 				"/callback",
 				expect.any(Function),
 			);
+		});
+
+		describe("listen host", () => {
+			/**
+			 * Starts the OAuth flow far enough to reach `server.listen()` and
+			 * returns the options it was called with. `listen` never resolves, so
+			 * the command is left waiting for a callback that never arrives.
+			 */
+			const captureListenOptions = async (): Promise<{
+				port: number;
+				host: string;
+			}> => {
+				mocks.mockFastifyInstance.listen.mockImplementation(
+					() => new Promise(() => {}),
+				);
+
+				void command.execute([]).catch(() => {});
+				await new Promise((resolve) => setTimeout(resolve, 10));
+
+				expect(mocks.mockFastifyInstance.listen).toHaveBeenCalledTimes(1);
+				return mocks.mockFastifyInstance.listen.mock.calls[0][0];
+			};
+
+			it("falls back to localhost when neither variable is set", async () => {
+				expect(await captureListenOptions()).toMatchObject({
+					host: "localhost",
+					port: 3456,
+				});
+			});
+
+			it("falls back to 0.0.0.0 when CYRUS_HOST_EXTERNAL is true", async () => {
+				process.env.CYRUS_HOST_EXTERNAL = "true";
+
+				expect(await captureListenOptions()).toMatchObject({
+					host: "0.0.0.0",
+				});
+			});
+
+			it("uses CYRUS_SERVER_HOST when set", async () => {
+				process.env.CYRUS_SERVER_HOST = "127.0.0.1";
+
+				expect(await captureListenOptions()).toMatchObject({
+					host: "127.0.0.1",
+				});
+			});
+
+			it("lets CYRUS_SERVER_HOST override CYRUS_HOST_EXTERNAL", async () => {
+				// The tunnelled self-host case: bind loopback while keeping
+				// CYRUS_HOST_EXTERNAL=true for direct webhook verification.
+				process.env.CYRUS_HOST_EXTERNAL = "true";
+				process.env.CYRUS_SERVER_HOST = "127.0.0.1";
+
+				expect(await captureListenOptions()).toMatchObject({
+					host: "127.0.0.1",
+				});
+			});
+
+			it("rejects a non-loopback override without CYRUS_HOST_EXTERNAL before listening", async () => {
+				process.env.CYRUS_SERVER_HOST = "0.0.0.0";
+
+				await expect(command.execute([])).rejects.toThrow(
+					"process.exit called",
+				);
+				expect(mockExit).toHaveBeenCalledWith(1);
+				// The callback listener never opens.
+				expect(mocks.mockFastifyInstance.listen).not.toHaveBeenCalled();
+			});
 		});
 
 		it("should open browser with correct OAuth URL", async () => {

--- a/apps/cli/src/commands/SelfAuthCommand.ts
+++ b/apps/cli/src/commands/SelfAuthCommand.ts
@@ -18,12 +18,7 @@ import { BaseCommand } from "./ICommand.js";
 export class SelfAuthCommand extends BaseCommand {
 	private server: FastifyInstance | null = null;
 	private callbackPort = parseInt(process.env.CYRUS_SERVER_PORT || "3456", 10);
-	/**
-	 * Resolved and validated once in `execute` so both the Cloudflare-tunnel
-	 * `SharedApplicationServer` and the OAuth-callback listener bind the same
-	 * address. A non-loopback override without `CYRUS_HOST_EXTERNAL=true` is
-	 * rejected before either listener opens.
-	 */
+	/** Resolved once in `execute` so both listeners bind the same address. */
 	private listenHost = "localhost";
 
 	async execute(_args: string[]): Promise<void> {
@@ -67,10 +62,8 @@ export class SelfAuthCommand extends BaseCommand {
 		console.log(`   Callback port: ${this.callbackPort}`);
 		console.log();
 
-		// Resolve and validate the bind address once, before any listener opens.
-		// A non-loopback CYRUS_SERVER_HOST without CYRUS_HOST_EXTERNAL=true is
-		// rejected: the callback port would be on the network while webhooks are
-		// verified in proxy mode and source-IP validation is off by default.
+		// Validate before any listener opens, so a rejected configuration never
+		// gets bound.
 		const isExternalHost =
 			process.env.CYRUS_HOST_EXTERNAL?.toLowerCase().trim() === "true";
 		this.listenHost = resolveServerHost(
@@ -88,9 +81,8 @@ export class SelfAuthCommand extends BaseCommand {
 				this.logger.info("Starting cloudflare tunnel...");
 
 				const { SharedApplicationServer } = await import("cyrus-edge-worker");
-				// 2nd arg is the bind address, not a public URL. Only the port is
-				// read by startCloudflareTunnel today, but passing baseUrl here
-				// would fail the moment anyone calls start() on this instance.
+				// 2nd arg is the bind address, not a public URL - passing baseUrl
+				// here would break start() on this instance.
 				const sharedApplicationServer = new SharedApplicationServer(
 					this.callbackPort,
 					this.listenHost,

--- a/apps/cli/src/commands/SelfAuthCommand.ts
+++ b/apps/cli/src/commands/SelfAuthCommand.ts
@@ -8,6 +8,7 @@ import {
 } from "cyrus-core";
 import Fastify, { type FastifyInstance } from "fastify";
 import open from "open";
+import { resolveServerHost, serverHostError } from "../config/constants.js";
 import { BaseCommand } from "./ICommand.js";
 
 /**
@@ -17,6 +18,13 @@ import { BaseCommand } from "./ICommand.js";
 export class SelfAuthCommand extends BaseCommand {
 	private server: FastifyInstance | null = null;
 	private callbackPort = parseInt(process.env.CYRUS_SERVER_PORT || "3456", 10);
+	/**
+	 * Resolved and validated once in `execute` so both the Cloudflare-tunnel
+	 * `SharedApplicationServer` and the OAuth-callback listener bind the same
+	 * address. A non-loopback override without `CYRUS_HOST_EXTERNAL=true` is
+	 * rejected before either listener opens.
+	 */
+	private listenHost = "localhost";
 
 	async execute(_args: string[]): Promise<void> {
 		console.log("\nCyrus Linear Self-Authentication");
@@ -59,14 +67,33 @@ export class SelfAuthCommand extends BaseCommand {
 		console.log(`   Callback port: ${this.callbackPort}`);
 		console.log();
 
+		// Resolve and validate the bind address once, before any listener opens.
+		// A non-loopback CYRUS_SERVER_HOST without CYRUS_HOST_EXTERNAL=true is
+		// rejected: the callback port would be on the network while webhooks are
+		// verified in proxy mode and source-IP validation is off by default.
+		const isExternalHost =
+			process.env.CYRUS_HOST_EXTERNAL?.toLowerCase().trim() === "true";
+		this.listenHost = resolveServerHost(
+			process.env.CYRUS_SERVER_HOST,
+			isExternalHost,
+		);
+		const hostError = serverHostError(this.listenHost, isExternalHost);
+		if (hostError) {
+			this.logError(hostError);
+			process.exit(1);
+		}
+
 		try {
 			if (process.env.CLOUDFLARE_TOKEN) {
 				this.logger.info("Starting cloudflare tunnel...");
 
 				const { SharedApplicationServer } = await import("cyrus-edge-worker");
+				// 2nd arg is the bind address, not a public URL. Only the port is
+				// read by startCloudflareTunnel today, but passing baseUrl here
+				// would fail the moment anyone calls start() on this instance.
 				const sharedApplicationServer = new SharedApplicationServer(
 					this.callbackPort,
-					baseUrl,
+					this.listenHost,
 					false,
 				);
 				await sharedApplicationServer.startCloudflareTunnel(
@@ -187,12 +214,8 @@ export class SelfAuthCommand extends BaseCommand {
 				reject(new Error("Missing authorization code"));
 			});
 
-			const isExternalHost =
-				process.env.CYRUS_HOST_EXTERNAL?.toLowerCase().trim() === "true";
-			const listenHost = isExternalHost ? "0.0.0.0" : "localhost";
-
 			this.server
-				.listen({ port: this.callbackPort, host: listenHost })
+				.listen({ port: this.callbackPort, host: this.listenHost })
 				.then(() => {
 					console.log(
 						`Waiting for authorization on port ${this.callbackPort}...`,
@@ -247,7 +270,7 @@ export class SelfAuthCommand extends BaseCommand {
 			refresh_token?: string;
 		};
 
-		if (!data.access_token || !data.access_token.startsWith("lin_oauth_")) {
+		if (!data.access_token?.startsWith("lin_oauth_")) {
 			throw new Error("Invalid access token received");
 		}
 

--- a/apps/cli/src/config/constants.test.ts
+++ b/apps/cli/src/config/constants.test.ts
@@ -85,10 +85,28 @@ describe("serverHostError", () => {
 			"LOCALHOST",
 			"127.0.0.1",
 			"127.1.2.3",
+			"127.255.255.254",
 			"::1",
 			"[::1]",
 		]) {
 			expect(serverHostError(host, false)).toBeNull();
+		}
+	});
+
+	it("rejects hostnames that only look like 127.0.0.0/8", () => {
+		for (const host of [
+			"127.example.com",
+			"127.0.0.1.nip.io",
+			"127.attacker.net",
+			// Not valid dotted-quads, so not addresses Cyrus will treat as loopback.
+			"127.1",
+			"127",
+			"127.0.0.256",
+			"127.0.0.01",
+		]) {
+			expect(serverHostError(host, false)).toContain(
+				`CYRUS_SERVER_HOST=${host}`,
+			);
 		}
 	});
 

--- a/apps/cli/src/config/constants.test.ts
+++ b/apps/cli/src/config/constants.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_SERVER_PORT,
+	parsePort,
+	resolveServerHost,
+	serverHostError,
+} from "./constants.js";
+
+describe("parsePort", () => {
+	it("returns the default when unset or empty", () => {
+		expect(parsePort(undefined, DEFAULT_SERVER_PORT)).toBe(DEFAULT_SERVER_PORT);
+		expect(parsePort("", DEFAULT_SERVER_PORT)).toBe(DEFAULT_SERVER_PORT);
+	});
+
+	it("parses a valid port", () => {
+		expect(parsePort("8080", DEFAULT_SERVER_PORT)).toBe(8080);
+	});
+
+	it("returns the default for non-numeric or out-of-range values", () => {
+		expect(parsePort("not-a-port", DEFAULT_SERVER_PORT)).toBe(
+			DEFAULT_SERVER_PORT,
+		);
+		expect(parsePort("0", DEFAULT_SERVER_PORT)).toBe(DEFAULT_SERVER_PORT);
+		expect(parsePort("70000", DEFAULT_SERVER_PORT)).toBe(DEFAULT_SERVER_PORT);
+	});
+});
+
+describe("resolveServerHost", () => {
+	describe("fallback (CYRUS_SERVER_HOST unset)", () => {
+		it("binds all interfaces when CYRUS_HOST_EXTERNAL is enabled", () => {
+			expect(resolveServerHost(undefined, true)).toBe("0.0.0.0");
+		});
+
+		it("binds localhost when CYRUS_HOST_EXTERNAL is disabled", () => {
+			expect(resolveServerHost(undefined, false)).toBe("localhost");
+		});
+
+		it("falls back for an empty or whitespace-only override", () => {
+			expect(resolveServerHost("", true)).toBe("0.0.0.0");
+			expect(resolveServerHost("   ", true)).toBe("0.0.0.0");
+			expect(resolveServerHost("", false)).toBe("localhost");
+			expect(resolveServerHost("   ", false)).toBe("localhost");
+		});
+	});
+
+	describe("override (CYRUS_SERVER_HOST set)", () => {
+		it("takes precedence over the CYRUS_HOST_EXTERNAL derivation", () => {
+			// The case from the issue: tunnelled/proxied self-host that wants a
+			// loopback bind while keeping direct webhook verification.
+			expect(resolveServerHost("127.0.0.1", true)).toBe("127.0.0.1");
+			expect(resolveServerHost("0.0.0.0", false)).toBe("0.0.0.0");
+		});
+
+		it("accepts any address, not just the two derived values", () => {
+			expect(resolveServerHost("::1", true)).toBe("::1");
+			expect(resolveServerHost("192.168.1.10", false)).toBe("192.168.1.10");
+		});
+
+		it("trims surrounding whitespace", () => {
+			expect(resolveServerHost("  127.0.0.1  ", true)).toBe("127.0.0.1");
+		});
+	});
+});
+
+describe("serverHostError", () => {
+	it("rejects when an override binds a non-loopback address outside external mode", () => {
+		const error = serverHostError("0.0.0.0", false);
+
+		expect(error).toContain("CYRUS_SERVER_HOST=0.0.0.0");
+		expect(error).toContain("CYRUS_HOST_EXTERNAL");
+		// Spells out the requirement so the operator knows the fix.
+		expect(error).toContain("CYRUS_HOST_EXTERNAL=true");
+	});
+
+	it("rejects a specific non-loopback interface address too", () => {
+		expect(serverHostError("192.168.1.10", false)).toContain(
+			"CYRUS_SERVER_HOST=192.168.1.10",
+		);
+	});
+
+	it("stays quiet for loopback addresses", () => {
+		for (const host of [
+			"localhost",
+			"Localhost",
+			"LOCALHOST",
+			"127.0.0.1",
+			"127.1.2.3",
+			"::1",
+			"[::1]",
+		]) {
+			expect(serverHostError(host, false)).toBeNull();
+		}
+	});
+
+	it("stays quiet in external mode, where a public bind is the point", () => {
+		expect(serverHostError("0.0.0.0", true)).toBeNull();
+		expect(serverHostError("127.0.0.1", true)).toBeNull();
+	});
+
+	it("never fires for a derived address", () => {
+		// The only non-loopback derivation requires isExternalHost.
+		expect(
+			serverHostError(resolveServerHost(undefined, false), false),
+		).toBeNull();
+		expect(
+			serverHostError(resolveServerHost(undefined, true), true),
+		).toBeNull();
+	});
+});

--- a/apps/cli/src/config/constants.ts
+++ b/apps/cli/src/config/constants.ts
@@ -20,3 +20,68 @@ export function parsePort(
 		? defaultPort
 		: parsed;
 }
+
+/**
+ * Resolve the address the HTTP server binds to.
+ *
+ * `CYRUS_SERVER_HOST` is an explicit override; when it is unset the address is
+ * derived from `CYRUS_HOST_EXTERNAL` exactly as before.
+ *
+ * The two are separate because `CYRUS_HOST_EXTERNAL` is not a bind knob: it also
+ * selects the webhook verification mode (direct signature vs proxied) and the
+ * default for webhook source-IP validation. The override lets a deployment that
+ * is fronted by a tunnel or reverse proxy on the same host bind loopback without
+ * changing either of those.
+ *
+ * @param value Raw `CYRUS_SERVER_HOST` value, if set
+ * @param isExternalHost Whether `CYRUS_HOST_EXTERNAL` is enabled
+ */
+export function resolveServerHost(
+	value: string | undefined,
+	isExternalHost: boolean,
+): string {
+	return value?.trim() || (isExternalHost ? "0.0.0.0" : "localhost");
+}
+
+/** Addresses that only the local machine can reach. */
+function isLoopbackHost(host: string): boolean {
+	const lower = host.toLowerCase();
+	return (
+		lower === "localhost" ||
+		lower === "::1" ||
+		lower === "[::1]" ||
+		// 127.0.0.0/8 is all loopback; the prefix check is case-insensitive
+		// because digits aren't, but lowercasing keeps it consistent.
+		lower.startsWith("127.")
+	);
+}
+
+/**
+ * Error text for a `CYRUS_SERVER_HOST` that widens exposure rather than
+ * narrowing it, or `null` when the resolved address is unremarkable.
+ *
+ * Binding a non-loopback address without `CYRUS_HOST_EXTERNAL=true` is a
+ * combination that was unreachable before `CYRUS_SERVER_HOST` existed, and it is
+ * the dangerous one: webhook source-IP validation defaults off and webhooks are
+ * verified in proxy mode against `CYRUS_API_KEY`, so the port is reachable from
+ * the network with the weaker of the two verification paths in front of it.
+ *
+ * Only an explicit override can produce it - the derived address for
+ * `CYRUS_HOST_EXTERNAL=false` is loopback. Cyrus therefore rejects the
+ * configuration before opening the listener rather than binding it: a non-
+ * loopback override requires `CYRUS_HOST_EXTERNAL=true`, otherwise Cyrus stays
+ * loopback-only.
+ */
+export function serverHostError(
+	host: string,
+	isExternalHost: boolean,
+): string | null {
+	if (isExternalHost || isLoopbackHost(host)) return null;
+
+	return (
+		`CYRUS_SERVER_HOST=${host} binds a non-loopback address while CYRUS_HOST_EXTERNAL is not set. ` +
+		"A non-loopback override requires CYRUS_HOST_EXTERNAL=true (direct webhook signature verification " +
+		"and source-IP validation); without it Cyrus is loopback-only. Set CYRUS_HOST_EXTERNAL=true if " +
+		"this instance receives webhooks directly, or use a loopback address."
+	);
+}

--- a/apps/cli/src/config/constants.ts
+++ b/apps/cli/src/config/constants.ts
@@ -2,6 +2,8 @@
  * Application constants
  */
 
+import { isIPv4 } from "node:net";
+
 /**
  * Default server port for OAuth callbacks and webhooks
  */
@@ -24,14 +26,10 @@ export function parsePort(
 /**
  * Resolve the address the HTTP server binds to.
  *
- * `CYRUS_SERVER_HOST` is an explicit override; when it is unset the address is
- * derived from `CYRUS_HOST_EXTERNAL` exactly as before.
- *
- * The two are separate because `CYRUS_HOST_EXTERNAL` is not a bind knob: it also
- * selects the webhook verification mode (direct signature vs proxied) and the
- * default for webhook source-IP validation. The override lets a deployment that
- * is fronted by a tunnel or reverse proxy on the same host bind loopback without
- * changing either of those.
+ * `CYRUS_HOST_EXTERNAL` is not a bind knob: it also selects the webhook
+ * verification mode and the source-IP validation default. `CYRUS_SERVER_HOST`
+ * exists so a deployment fronted by a tunnel or reverse proxy can move the bind
+ * address without changing either of those.
  *
  * @param value Raw `CYRUS_SERVER_HOST` value, if set
  * @param isExternalHost Whether `CYRUS_HOST_EXTERNAL` is enabled
@@ -43,34 +41,24 @@ export function resolveServerHost(
 	return value?.trim() || (isExternalHost ? "0.0.0.0" : "localhost");
 }
 
-/** Addresses that only the local machine can reach. */
+/** Addresses only the local machine can reach. */
 function isLoopbackHost(host: string): boolean {
 	const lower = host.toLowerCase();
-	return (
-		lower === "localhost" ||
-		lower === "::1" ||
-		lower === "[::1]" ||
-		// 127.0.0.0/8 is all loopback; the prefix check is case-insensitive
-		// because digits aren't, but lowercasing keeps it consistent.
-		lower.startsWith("127.")
-	);
+	if (lower === "localhost" || lower === "::1" || lower === "[::1]") {
+		return true;
+	}
+	// Hostnames can start "127." too (`127.example.com`), so the address has to
+	// parse as IPv4 before the 127.0.0.0/8 prefix means anything.
+	return isIPv4(lower) && lower.startsWith("127.");
 }
 
 /**
- * Error text for a `CYRUS_SERVER_HOST` that widens exposure rather than
- * narrowing it, or `null` when the resolved address is unremarkable.
+ * Error text for a `CYRUS_SERVER_HOST` that binds beyond loopback without
+ * `CYRUS_HOST_EXTERNAL=true`, or `null` when the address is acceptable.
  *
- * Binding a non-loopback address without `CYRUS_HOST_EXTERNAL=true` is a
- * combination that was unreachable before `CYRUS_SERVER_HOST` existed, and it is
- * the dangerous one: webhook source-IP validation defaults off and webhooks are
- * verified in proxy mode against `CYRUS_API_KEY`, so the port is reachable from
- * the network with the weaker of the two verification paths in front of it.
- *
- * Only an explicit override can produce it - the derived address for
- * `CYRUS_HOST_EXTERNAL=false` is loopback. Cyrus therefore rejects the
- * configuration before opening the listener rather than binding it: a non-
- * loopback override requires `CYRUS_HOST_EXTERNAL=true`, otherwise Cyrus stays
- * loopback-only.
+ * That combination is unreachable without the override and is the dangerous
+ * one: the port is on the network while webhooks are verified in proxy mode and
+ * source-IP validation is off by default. Cyrus rejects it rather than binding.
  */
 export function serverHostError(
 	host: string,

--- a/apps/cli/src/config/constants.ts
+++ b/apps/cli/src/config/constants.ts
@@ -57,8 +57,8 @@ function isLoopbackHost(host: string): boolean {
  * `CYRUS_HOST_EXTERNAL=true`, or `null` when the address is acceptable.
  *
  * That combination is unreachable without the override and is the dangerous
- * one: the port is on the network while webhooks are verified in proxy mode and
- * source-IP validation is off by default. Cyrus rejects it rather than binding.
+ * one: the port is on the network while `CYRUS_HOST_EXTERNAL` still says the
+ * instance is not. Cyrus rejects it rather than binding.
  */
 export function serverHostError(
 	host: string,
@@ -68,8 +68,8 @@ export function serverHostError(
 
 	return (
 		`CYRUS_SERVER_HOST=${host} binds a non-loopback address while CYRUS_HOST_EXTERNAL is not set. ` +
-		"A non-loopback override requires CYRUS_HOST_EXTERNAL=true (direct webhook signature verification " +
-		"and source-IP validation); without it Cyrus is loopback-only. Set CYRUS_HOST_EXTERNAL=true if " +
-		"this instance receives webhooks directly, or use a loopback address."
+		"Without CYRUS_HOST_EXTERNAL=true, webhook source-IP validation is off by default and GitHub and " +
+		"Slack webhooks are verified in proxy mode, so Cyrus stays loopback-only. Set CYRUS_HOST_EXTERNAL=true " +
+		"if this instance receives webhooks directly, or use a loopback address."
 	);
 }

--- a/apps/cli/src/services/WorkerService.test.ts
+++ b/apps/cli/src/services/WorkerService.test.ts
@@ -15,6 +15,12 @@ const edgeWorkerInstances: Array<{
 	start: ReturnType<typeof vi.fn>;
 }> = [];
 
+const mocks = vi.hoisted(() => ({
+	mockSharedApplicationServer: vi.fn(),
+	mockConfigUpdater: vi.fn(),
+	mockSlackEventTransport: vi.fn(),
+}));
+
 vi.mock("cyrus-edge-worker", () => ({
 	EdgeWorker: vi.fn().mockImplementation(function (config: EdgeWorkerConfig) {
 		const instance = {
@@ -26,14 +32,19 @@ vi.mock("cyrus-edge-worker", () => ({
 		edgeWorkerInstances.push(instance);
 		return instance;
 	}),
+	SharedApplicationServer: mocks.mockSharedApplicationServer,
+}));
+
+vi.mock("cyrus-config-updater", () => ({
+	ConfigUpdater: mocks.mockConfigUpdater,
 }));
 
 vi.mock("cyrus-cloudflare-tunnel-client", () => ({
-	getCyrusAppUrl: vi.fn(),
+	getCyrusAppUrl: vi.fn(() => "https://app.example.com"),
 }));
 
 vi.mock("cyrus-slack-event-transport", () => ({
-	SlackEventTransport: vi.fn(),
+	SlackEventTransport: mocks.mockSlackEventTransport,
 }));
 
 const { WorkerService } = await import("./WorkerService.js");
@@ -48,6 +59,35 @@ const repository: RepositoryConfig = {
 describe("WorkerService", () => {
 	beforeEach(() => {
 		edgeWorkerInstances.length = 0;
+		mocks.mockSharedApplicationServer.mockReset();
+		mocks.mockConfigUpdater.mockReset();
+		mocks.mockSlackEventTransport.mockReset();
+
+		mocks.mockSharedApplicationServer.mockImplementation(function () {
+			return {
+				initializeFastify: vi.fn(),
+				getFastifyInstance: vi.fn().mockReturnValue({}),
+				start: vi.fn().mockResolvedValue(undefined),
+				stop: vi.fn().mockResolvedValue(undefined),
+			};
+		});
+		mocks.mockConfigUpdater.mockImplementation(function () {
+			return { register: vi.fn() };
+		});
+		mocks.mockSlackEventTransport.mockImplementation(function () {
+			return { register: vi.fn() };
+		});
+
+		// The bind-address tests read these, so they must not inherit the shell.
+		for (const key of [
+			"CYRUS_HOST_EXTERNAL",
+			"CYRUS_SERVER_HOST",
+			"CYRUS_SERVER_PORT",
+			"CLOUDFLARE_TOKEN",
+			"SLACK_SIGNING_SECRET",
+		]) {
+			vi.stubEnv(key, undefined as unknown as string);
+		}
 	});
 
 	afterEach(() => {
@@ -65,6 +105,8 @@ describe("WorkerService", () => {
 			success: vi.fn(),
 			error: vi.fn(),
 			warn: vi.fn(),
+			raw: vi.fn(),
+			divider: vi.fn(),
 		} as unknown as Logger;
 
 		return new WorkerService(
@@ -137,5 +179,165 @@ describe("WorkerService", () => {
 		});
 
 		expect(config.inferOpenCodeRunnerFromProviderModel).toBe(true);
+	});
+
+	describe("bind address", () => {
+		let service: WorkerService;
+
+		beforeEach(() => {
+			service = createWorkerService({ repositories: [] });
+		});
+
+		/** Host passed positionally as the 2nd arg of `new SharedApplicationServer(port, host)`. */
+		const preWorkerServerHost = (): string =>
+			mocks.mockSharedApplicationServer.mock.calls[0][1];
+
+		/** Host taken from the `EdgeWorkerConfig` handed to `new EdgeWorker(config)`. */
+		const edgeWorkerHost = (): string | undefined =>
+			edgeWorkerInstances[0]?.config.serverHost;
+
+		describe("setup-waiting / idle server", () => {
+			it("falls back to localhost when neither variable is set", async () => {
+				await service.startSetupWaitingMode();
+
+				expect(mocks.mockSharedApplicationServer).toHaveBeenCalledWith(
+					3456,
+					"localhost",
+				);
+			});
+
+			it("falls back to 0.0.0.0 when CYRUS_HOST_EXTERNAL is true", async () => {
+				vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+
+				await service.startIdleMode();
+
+				expect(preWorkerServerHost()).toBe("0.0.0.0");
+			});
+
+			it("uses CYRUS_SERVER_HOST when set", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+
+				await service.startSetupWaitingMode();
+
+				expect(preWorkerServerHost()).toBe("127.0.0.1");
+			});
+
+			it("lets CYRUS_SERVER_HOST override CYRUS_HOST_EXTERNAL", async () => {
+				vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+
+				await service.startIdleMode();
+
+				expect(preWorkerServerHost()).toBe("127.0.0.1");
+			});
+		});
+
+		describe("edge worker", () => {
+			const start = () => service.startEdgeWorker({ repositories: [] });
+
+			it("falls back to localhost when neither variable is set", async () => {
+				await start();
+
+				expect(edgeWorkerHost()).toBe("localhost");
+			});
+
+			it("falls back to 0.0.0.0 when CYRUS_HOST_EXTERNAL is true", async () => {
+				vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+
+				await start();
+
+				expect(edgeWorkerHost()).toBe("0.0.0.0");
+			});
+
+			it("uses CYRUS_SERVER_HOST when set", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+
+				await start();
+
+				expect(edgeWorkerHost()).toBe("127.0.0.1");
+			});
+
+			it("lets CYRUS_SERVER_HOST override CYRUS_HOST_EXTERNAL", async () => {
+				// The tunnelled self-host case: bind loopback while keeping
+				// CYRUS_HOST_EXTERNAL=true for direct webhook verification.
+				vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+
+				await start();
+
+				expect(edgeWorkerHost()).toBe("127.0.0.1");
+			});
+		});
+
+		describe("non-loopback rejection", () => {
+			it("rejects an override that binds non-loopback outside external mode", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "0.0.0.0");
+
+				await expect(
+					service.startEdgeWorker({ repositories: [] }),
+				).rejects.toThrow("CYRUS_SERVER_HOST=0.0.0.0");
+				// Startup fails before the listener is opened.
+				expect(edgeWorkerInstances).toHaveLength(0);
+				expect(mocks.mockSharedApplicationServer).not.toHaveBeenCalled();
+			});
+
+			it("rejects from the setup-waiting server too", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "192.168.1.10");
+
+				await expect(service.startSetupWaitingMode()).rejects.toThrow(
+					"CYRUS_SERVER_HOST=192.168.1.10",
+				);
+				expect(mocks.mockSharedApplicationServer).not.toHaveBeenCalled();
+			});
+
+			it("rejects a hostname that merely looks like loopback", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.example.com");
+
+				await expect(service.startSetupWaitingMode()).rejects.toThrow(
+					"CYRUS_SERVER_HOST=127.example.com",
+				);
+				expect(mocks.mockSharedApplicationServer).not.toHaveBeenCalled();
+			});
+
+			it("does not reject for a loopback override", async () => {
+				vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+
+				await service.startSetupWaitingMode();
+
+				expect(mocks.mockSharedApplicationServer).toHaveBeenCalledWith(
+					3456,
+					"127.0.0.1",
+				);
+			});
+
+			it("does not reject when CYRUS_HOST_EXTERNAL makes the public bind intentional", async () => {
+				vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+
+				await service.startEdgeWorker({ repositories: [] });
+
+				expect(edgeWorkerInstances).toHaveLength(1);
+			});
+		});
+
+		it("does not change webhook verification mode", async () => {
+			// CYRUS_SERVER_HOST moves the bind address only. Slack direct
+			// verification stays gated on CYRUS_HOST_EXTERNAL alone.
+			vi.stubEnv("CYRUS_SERVER_HOST", "127.0.0.1");
+			vi.stubEnv("SLACK_SIGNING_SECRET", "slack-secret");
+
+			await service.startSetupWaitingMode();
+			expect(mocks.mockSlackEventTransport).not.toHaveBeenCalled();
+
+			await service.stopWaitingServer();
+			vi.stubEnv("CYRUS_HOST_EXTERNAL", "true");
+
+			await service.startSetupWaitingMode();
+			expect(mocks.mockSlackEventTransport).toHaveBeenCalledWith(
+				expect.objectContaining({
+					verificationMode: "direct",
+					secret: "slack-secret",
+				}),
+			);
+		});
 	});
 });

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -8,7 +8,12 @@ import type {
 import type { GitService, SharedApplicationServer } from "cyrus-edge-worker";
 import { EdgeWorker } from "cyrus-edge-worker";
 import { SlackEventTransport } from "cyrus-slack-event-transport";
-import { DEFAULT_SERVER_PORT, parsePort } from "../config/constants.js";
+import {
+	DEFAULT_SERVER_PORT,
+	parsePort,
+	resolveServerHost,
+	serverHostError,
+} from "../config/constants.js";
 import type { Workspace } from "../config/types.js";
 import type { ConfigService } from "./ConfigService.js";
 import type { Logger } from "./Logger.js";
@@ -107,7 +112,11 @@ export class WorkerService {
 			process.env.CYRUS_SERVER_PORT,
 			DEFAULT_SERVER_PORT,
 		);
-		const serverHost = isExternalHost ? "0.0.0.0" : "localhost";
+		const serverHost = resolveServerHost(
+			process.env.CYRUS_SERVER_HOST,
+			isExternalHost,
+		);
+		this.rejectRiskyBind(serverHost, isExternalHost);
 
 		this.setupWaitingServer = new SharedApplicationServer(
 			serverPort,
@@ -150,6 +159,17 @@ export class WorkerService {
 			this.logger.info(line);
 		}
 		this.logger.divider(70);
+	}
+
+	/**
+	 * Reject a `CYRUS_SERVER_HOST` that exposes the port more widely than the
+	 * deployment's webhook configuration expects. A non-loopback override
+	 * requires `CYRUS_HOST_EXTERNAL=true`; without it Cyrus is loopback-only and
+	 * startup fails before the listener is opened.
+	 */
+	private rejectRiskyBind(serverHost: string, isExternalHost: boolean): void {
+		const error = serverHostError(serverHost, isExternalHost);
+		if (error) throw new Error(error);
 	}
 
 	/**
@@ -205,6 +225,11 @@ export class WorkerService {
 		// Determine if using external host
 		const isExternalHost =
 			process.env.CYRUS_HOST_EXTERNAL?.toLowerCase().trim() === "true";
+		const serverHost = resolveServerHost(
+			process.env.CYRUS_SERVER_HOST,
+			isExternalHost,
+		);
+		this.rejectRiskyBind(serverHost, isExternalHost);
 
 		// Load config once for model defaults
 		const edgeConfig = this.configService.load();
@@ -266,7 +291,7 @@ export class WorkerService {
 			linearWorkspaces: edgeConfig.linearWorkspaces,
 			webhookBaseUrl: process.env.CYRUS_BASE_URL,
 			serverPort: parsePort(process.env.CYRUS_SERVER_PORT, DEFAULT_SERVER_PORT),
-			serverHost: isExternalHost ? "0.0.0.0" : "localhost",
+			serverHost,
 			ngrokAuthToken,
 			// User access control configuration
 			userAccessControl: edgeConfig.userAccessControl,

--- a/apps/cli/src/services/WorkerService.ts
+++ b/apps/cli/src/services/WorkerService.ts
@@ -162,10 +162,8 @@ export class WorkerService {
 	}
 
 	/**
-	 * Reject a `CYRUS_SERVER_HOST` that exposes the port more widely than the
-	 * deployment's webhook configuration expects. A non-loopback override
-	 * requires `CYRUS_HOST_EXTERNAL=true`; without it Cyrus is loopback-only and
-	 * startup fails before the listener is opened.
+	 * Throws before any listener is opened, so a rejected `CYRUS_SERVER_HOST`
+	 * never gets bound.
 	 */
 	private rejectRiskyBind(serverHost: string, isExternalHost: boolean): void {
 		const error = serverHostError(serverHost, isExternalHost);

--- a/docs/CLOUDFLARE_TUNNEL.md
+++ b/docs/CLOUDFLARE_TUNNEL.md
@@ -76,7 +76,7 @@ Cyrus will automatically start the Cloudflare tunnel in the background when it d
 
 `cloudflared` reaches the origin over loopback, so if you have `CYRUS_HOST_EXTERNAL=true` set, add
 `export CYRUS_SERVER_HOST=127.0.0.1` to keep the port off your public interfaces. See
-[Self-Hosting](./SELF_HOSTING.md#43-cyrus_server_host) for what the override does and does not change.
+[Self-Hosting](./SELF_HOSTING.md#43-choosing-a-bind-address) for what the override does and does not change.
 
 ---
 

--- a/docs/CLOUDFLARE_TUNNEL.md
+++ b/docs/CLOUDFLARE_TUNNEL.md
@@ -74,6 +74,11 @@ export CLOUDFLARE_TOKEN=eyJhIjoiXXXXXXX...your_token_here...XXXXXXX
 
 Cyrus will automatically start the Cloudflare tunnel in the background when it detects the `CLOUDFLARE_TOKEN` environment variable.
 
+`cloudflared` connects outbound and reaches the origin over loopback, so nothing off-box needs to connect to the port
+directly. If you have `CYRUS_HOST_EXTERNAL=true` set, add `export CYRUS_SERVER_HOST=127.0.0.1` to keep the port off your
+public interfaces - it changes the bind address only, leaving direct webhook signature verification and source-IP
+validation on. See [Self-Hosting](./SELF_HOSTING.md) for the full explanation.
+
 ---
 
 ## Troubleshooting

--- a/docs/CLOUDFLARE_TUNNEL.md
+++ b/docs/CLOUDFLARE_TUNNEL.md
@@ -74,10 +74,9 @@ export CLOUDFLARE_TOKEN=eyJhIjoiXXXXXXX...your_token_here...XXXXXXX
 
 Cyrus will automatically start the Cloudflare tunnel in the background when it detects the `CLOUDFLARE_TOKEN` environment variable.
 
-`cloudflared` connects outbound and reaches the origin over loopback, so nothing off-box needs to connect to the port
-directly. If you have `CYRUS_HOST_EXTERNAL=true` set, add `export CYRUS_SERVER_HOST=127.0.0.1` to keep the port off your
-public interfaces - it changes the bind address only, leaving direct webhook signature verification and source-IP
-validation on. See [Self-Hosting](./SELF_HOSTING.md) for the full explanation.
+`cloudflared` reaches the origin over loopback, so if you have `CYRUS_HOST_EXTERNAL=true` set, add
+`export CYRUS_SERVER_HOST=127.0.0.1` to keep the port off your public interfaces. See
+[Self-Hosting](./SELF_HOSTING.md#43-cyrus_server_host) for what the override does and does not change.
 
 ---
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -197,24 +197,20 @@ ANTHROPIC_API_KEY=your-api-key
 # CLOUDFLARE_TOKEN=your-cloudflare-token
 ```
 
-### 4.3 `CYRUS_SERVER_HOST`
+### 4.3 Choosing a Bind Address
 
 `CYRUS_SERVER_HOST` sets the address Cyrus listens on. Leave it unset and Cyrus binds `0.0.0.0` when
-`CYRUS_HOST_EXTERNAL=true` and `localhost` otherwise - the right default when webhook providers connect to the port
-directly.
+`CYRUS_HOST_EXTERNAL=true` and `localhost` otherwise, which is what you want when webhook providers connect to the
+port directly.
 
-Set it when a tunnel or a reverse proxy on the same host fronts Cyrus. `cloudflared` connects outbound and reaches the
-origin over loopback, as does an nginx or Caddy on the same box, so nothing off-box needs to reach the port.
+Set it when a tunnel or a reverse proxy on the same host fronts Cyrus and nothing off-box needs to reach the port.
 `CYRUS_SERVER_HOST=127.0.0.1` alongside `CYRUS_HOST_EXTERNAL=true` keeps the port off your public interfaces while
-leaving direct webhook signature verification and source-IP validation on.
+leaving direct webhook signature verification and source-IP validation on. Turning `CYRUS_HOST_EXTERNAL` off is not an
+alternative: that flag also selects the webhook verification mode and the source-IP validation default.
 
-Do not move the bind address by turning `CYRUS_HOST_EXTERNAL` off instead: that flag also selects the webhook
-verification mode and the source-IP validation default.
-
-A non-loopback `CYRUS_SERVER_HOST` requires `CYRUS_HOST_EXTERNAL=true`. Without it the port would be on the network
-while webhooks are verified in proxy mode and source-IP validation is off, so Cyrus rejects the configuration at
-startup and stays loopback-only. Loopback means `localhost`, `::1`, or an address in `127.0.0.0/8` - a hostname that
-merely starts with `127.` is not accepted.
+A non-loopback `CYRUS_SERVER_HOST` requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at
+startup rather than putting the port on the network with webhooks verified in proxy mode. Loopback means `localhost`,
+`::1`, or an address in `127.0.0.0/8` - a hostname that merely starts with `127.` is not accepted.
 
 ---
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -197,21 +197,24 @@ ANTHROPIC_API_KEY=your-api-key
 # CLOUDFLARE_TOKEN=your-cloudflare-token
 ```
 
-**`CYRUS_SERVER_HOST`** sets the address Cyrus listens on. Leave it unset and Cyrus binds `0.0.0.0` when
-`CYRUS_HOST_EXTERNAL=true` and `localhost` otherwise, which is what you want if webhook providers connect to the port
+### 4.3 `CYRUS_SERVER_HOST`
+
+`CYRUS_SERVER_HOST` sets the address Cyrus listens on. Leave it unset and Cyrus binds `0.0.0.0` when
+`CYRUS_HOST_EXTERNAL=true` and `localhost` otherwise - the right default when webhook providers connect to the port
 directly.
 
-Set it when you front Cyrus with a tunnel or a reverse proxy on the same host - `cloudflared` connects outbound and
-reaches the origin over loopback, as does an nginx or Caddy on the same box, so nothing off-box needs to reach the port.
+Set it when a tunnel or a reverse proxy on the same host fronts Cyrus. `cloudflared` connects outbound and reaches the
+origin over loopback, as does an nginx or Caddy on the same box, so nothing off-box needs to reach the port.
 `CYRUS_SERVER_HOST=127.0.0.1` alongside `CYRUS_HOST_EXTERNAL=true` keeps the port off your public interfaces while
-leaving direct webhook signature verification and source-IP validation on. Do not use it to change the bind address by
-turning `CYRUS_HOST_EXTERNAL` off: that flag also selects the webhook verification mode and the IP-validation default.
+leaving direct webhook signature verification and source-IP validation on.
 
-The mirror-image mistake is worth naming too. Pointing `CYRUS_SERVER_HOST` at a non-loopback address *without*
-`CYRUS_HOST_EXTERNAL=true` would put the port on the network while webhooks are still verified in proxy mode and
-source-IP validation is off by default - the weaker path, exposed. Cyrus rejects that configuration at startup
-rather than binding it: a non-loopback override requires `CYRUS_HOST_EXTERNAL=true`. Without it, Cyrus stays
-loopback-only.
+Do not move the bind address by turning `CYRUS_HOST_EXTERNAL` off instead: that flag also selects the webhook
+verification mode and the source-IP validation default.
+
+A non-loopback `CYRUS_SERVER_HOST` requires `CYRUS_HOST_EXTERNAL=true`. Without it the port would be on the network
+while webhooks are verified in proxy mode and source-IP validation is off, so Cyrus rejects the configuration at
+startup and stays loopback-only. Loopback means `localhost`, `::1`, or an address in `127.0.0.0/8` - a hostname that
+merely starts with `127.` is not accepted.
 
 ---
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -181,6 +181,8 @@ Your env file (`~/.cyrus/.env`) should now contain:
 LINEAR_DIRECT_WEBHOOKS=true
 CYRUS_BASE_URL=https://your-public-url.com
 CYRUS_SERVER_PORT=3456
+# Optional: the address Cyrus binds to.
+# CYRUS_SERVER_HOST=127.0.0.1
 
 # Linear OAuth
 LINEAR_CLIENT_ID=your_client_id
@@ -194,6 +196,22 @@ ANTHROPIC_API_KEY=your-api-key
 # Optional: Cloudflare Tunnel
 # CLOUDFLARE_TOKEN=your-cloudflare-token
 ```
+
+**`CYRUS_SERVER_HOST`** sets the address Cyrus listens on. Leave it unset and Cyrus binds `0.0.0.0` when
+`CYRUS_HOST_EXTERNAL=true` and `localhost` otherwise, which is what you want if webhook providers connect to the port
+directly.
+
+Set it when you front Cyrus with a tunnel or a reverse proxy on the same host - `cloudflared` connects outbound and
+reaches the origin over loopback, as does an nginx or Caddy on the same box, so nothing off-box needs to reach the port.
+`CYRUS_SERVER_HOST=127.0.0.1` alongside `CYRUS_HOST_EXTERNAL=true` keeps the port off your public interfaces while
+leaving direct webhook signature verification and source-IP validation on. Do not use it to change the bind address by
+turning `CYRUS_HOST_EXTERNAL` off: that flag also selects the webhook verification mode and the IP-validation default.
+
+The mirror-image mistake is worth naming too. Pointing `CYRUS_SERVER_HOST` at a non-loopback address *without*
+`CYRUS_HOST_EXTERNAL=true` would put the port on the network while webhooks are still verified in proxy mode and
+source-IP validation is off by default - the weaker path, exposed. Cyrus rejects that configuration at startup
+rather than binding it: a non-loopback override requires `CYRUS_HOST_EXTERNAL=true`. Without it, Cyrus stays
+loopback-only.
 
 ---
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -209,8 +209,9 @@ leaving direct webhook signature verification and source-IP validation on. Turni
 alternative: that flag also selects the webhook verification mode and the source-IP validation default.
 
 A non-loopback `CYRUS_SERVER_HOST` requires `CYRUS_HOST_EXTERNAL=true`; otherwise Cyrus rejects the configuration at
-startup rather than putting the port on the network with webhooks verified in proxy mode. Loopback means `localhost`,
-`::1`, or an address in `127.0.0.0/8` - a hostname that merely starts with `127.` is not accepted.
+startup rather than putting the port on the network while `CYRUS_HOST_EXTERNAL` still says the instance is not
+reachable from outside. Loopback means `localhost`, `::1`, or an address in `127.0.0.0/8` - a hostname that merely
+starts with `127.` is not accepted.
 
 ---
 


### PR DESCRIPTION
Closes cyrusagents/cyrus#1408.

`CYRUS_SERVER_HOST` overrides the listen address. Unset, the address is derived from `CYRUS_HOST_EXTERNAL` as before, so nothing changes for anyone not setting it.

One helper in `apps/cli/src/config/constants.ts` - `value?.trim() || (isExternalHost ? "0.0.0.0" : "localhost")` - applied at the three sites that repeated the ternary: the setup-waiting/idle server, `EdgeWorkerConfig.serverHost` for the main worker, and the self-auth OAuth callback. `EdgeWorker` already reads `config.serverHost`, so nothing outside `apps/cli` changes.

`CYRUS_HOST_EXTERNAL` keeps its other two meanings, webhook verification mode and the IP-validation default. A test asserts Slack direct verification still gates on it alone, so the new variable can't drift into being a second switch for that.

### Warning on the combination this opens up

Splitting the flags makes one combination reachable that wasn't before: a non-loopback `CYRUS_SERVER_HOST` with `CYRUS_HOST_EXTERNAL` unset. That puts the port on the network while IP validation defaults off and webhooks fall back to proxy mode against `CYRUS_API_KEY` - which, unset, means `handleProxyWebhook` compares against the literal `Bearer ` and matches anything. Before this PR a public bind always came with IP validation on.

So `serverHostWarning()` logs at all three sites when the resolved host is non-loopback and `CYRUS_HOST_EXTERNAL` is false. It doesn't block the bind, and it can only fire on an explicit override.

### Two adjacent fixes

Both predate this PR but leave holes in the invariant it sets up. Say the word and I'll split them out:

* `RefreshTokenCommand` called `s.listen(port, cb)` with no host, binding every interface regardless of either variable. Its callback reads an OAuth token off the query string, and `callbackUrl` is already hardcoded to localhost.
* `SelfAuthCommand.ts:69` passed `baseUrl` as `SharedApplicationServer`'s host argument. Inert today because that instance is never started, wrong as soon as it is.

133 tests pass in `apps/cli`, 31 of them new, covering both directions of the override and the warning. Docs updated in `SELF_HOSTING.md`, `CLOUDFLARE_TUNNEL.md` and the CLI README, plus a changelog entry.

Two things I left alone. `Application.createTempServer()` passes no host, but the constructor already defaults to `localhost`. And `SelfAuthCommand`'s `finally { await this.cleanup() }` never runs, because both paths call `process.exit` first - that's a behaviour decision rather than a one-liner, so I'd rather raise it separately.