### PR TITLE
fix(edge-worker): stop re-fetching activities to read an id the payload already has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Posting an agent activity no longer triggers two extra Linear API requests: the id is read off the mutation payload instead of the Linear SDK's `agentActivity` getter, which re-fetches the activity on every access. ([#1325](https://github.com/cyrusagents/cyrus/issues/1325))
 - EdgeWorker state saves are now atomic, preventing a process interrupted during a save from leaving a truncated state file that strands in-flight sessions; empty and legacy-truncated state files also recover cleanly. Thanks @connor-tembo for the contribution. ([CYPACK-1486](https://linear.app/ceedar/issue/CYPACK-1486/can-you-add-a-changelog-entry-for-this), [#1444](https://github.com/cyrusagents/cyrus/pull/1444))
 
 ### Changed

--- a/packages/core/src/issue-tracker/IIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/IIssueTrackerService.ts
@@ -591,6 +591,9 @@ export interface IIssueTrackerService {
 	 * @remarks
 	 * This creates a tracking session for AI/bot activity on an issue.
 	 * The session can receive agent activities and user prompts.
+	 *
+	 * When only the created session's id is needed, read `result.agentSessionId`
+	 * rather than `result.agentSession` — see {@link IssueTrackerAgentSessionPayload}.
 	 */
 	createAgentSessionOnIssue(
 		input: AgentSessionCreateOnIssueInput,
@@ -702,6 +705,12 @@ export interface IIssueTrackerService {
 	 * This is the primary method for posting agent updates to Linear.
 	 * Activities are visible in the Linear UI as part of the agent session.
 	 * Ephemeral activities disappear when replaced by the next activity.
+	 *
+	 * When only the created activity's id is needed, read `result.agentActivityId`
+	 * rather than `result.agentActivity`: on the Linear SDK payload the latter is
+	 * a getter that issues a fresh `agentActivity(id:)` query on every access
+	 * (even a bare truthiness test), costing an extra API request for an id the
+	 * mutation response already carries.
 	 */
 	createAgentActivity(
 		input: AgentActivityCreateInput,

--- a/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
+++ b/packages/core/src/issue-tracker/adapters/CLIIssueTrackerService.ts
@@ -965,6 +965,7 @@ export class CLIIssueTrackerService
 			success: true,
 			lastSyncId,
 			agentSession: Promise.resolve(agentSession),
+			agentSessionId: agentSession.id,
 		};
 
 		return payload;
@@ -1356,6 +1357,7 @@ export class CLIIssueTrackerService
 		// AgentSessionManager expects result.agentActivity to be promise-like
 		return {
 			agentActivity: Promise.resolve({ id: activityId }),
+			agentActivityId: activityId,
 			success: true,
 			lastSyncId: Date.now(),
 		} as AgentActivityPayload;

--- a/packages/core/src/issue-tracker/types.ts
+++ b/packages/core/src/issue-tracker/types.ts
@@ -413,8 +413,12 @@ export type IssueTrackerAgentSessionPayload = Pick<
 	LinearSDK.AgentSessionPayload,
 	"success" | "lastSyncId"
 > & {
-	// AgentSession property - use Promise instead of LinearFetch
+	// AgentSession property - use Promise instead of LinearFetch.
+	// Prefer `agentSessionId` where only the id is needed: reading `agentSession`
+	// triggers a fetch of the whole session, whereas the id is already known.
 	agentSession?: Promise<IssueTrackerAgentSession>;
+	/** The ID of the agent session that was created or updated. */
+	agentSessionId?: string;
 };
 
 /**
@@ -528,6 +532,10 @@ export type AgentActivityCreateInput =
 /**
  * Agent activity payload type.
  * Returned from createAgentActivity mutation - contains success status and created activity.
+ *
+ * Prefer `agentActivityId` where only the id is needed: `agentActivity` is a
+ * getter that re-fetches the activity with a fresh `agentActivity(id:)` query
+ * on every access, whereas the id is already on the mutation payload.
  *
  * @see {@link LinearSDK.AgentActivityPayload}
  */

--- a/packages/edge-worker/src/ActivityPoster.ts
+++ b/packages/edge-worker/src/ActivityPoster.ts
@@ -29,10 +29,10 @@ export class ActivityPoster {
 		try {
 			const result = await issueTracker.createAgentActivity(input);
 			if (result.success) {
-				if (result.agentActivity) {
-					const activity = await result.agentActivity;
-					this.logger.debug(`Created ${label} activity ${activity.id}`);
-					return activity.id;
+				const activityId = result.agentActivityId;
+				if (activityId) {
+					this.logger.debug(`Created ${label} activity ${activityId}`);
+					return activityId;
 				}
 				this.logger.debug(`Created ${label}`);
 				return null;

--- a/packages/edge-worker/src/sinks/LinearActivitySink.ts
+++ b/packages/edge-worker/src/sinks/LinearActivitySink.ts
@@ -97,9 +97,8 @@ export class LinearActivitySink implements IActivitySink {
 			}),
 		});
 
-		if (result.success && result.agentActivity) {
-			const agentActivity = await result.agentActivity;
-			return { activityId: agentActivity.id };
+		if (result.success && result.agentActivityId) {
+			return { activityId: result.agentActivityId };
 		}
 
 		return {};
@@ -125,14 +124,12 @@ export class LinearActivitySink implements IActivitySink {
 			);
 		}
 
-		// Extract session ID from the result
-		// Result has `agentSession` property that may be a Promise
-		const session = await result.agentSession;
-		if (!session) {
+		const sessionId = result.agentSessionId;
+		if (!sessionId) {
 			throw new Error(
 				`Failed to create agent session for issue ${issueId}: session is undefined`,
 			);
 		}
-		return session.id;
+		return sessionId;
 	}
 }

--- a/packages/edge-worker/test/ActivityPoster.test.ts
+++ b/packages/edge-worker/test/ActivityPoster.test.ts
@@ -9,7 +9,7 @@ describe("ActivityPoster", () => {
 	beforeEach(() => {
 		createAgentActivity = vi.fn().mockResolvedValue({
 			success: true,
-			agentActivity: Promise.resolve({ id: "activity-1" }),
+			agentActivityId: "activity-1",
 		});
 
 		poster = new ActivityPoster(
@@ -68,5 +68,57 @@ describe("ActivityPoster", () => {
 		expect(result).toContain("missing package @fake/missing");
 		expect(result).not.toContain("sudo privileges");
 		expect(result).not.toContain("/settings/packages");
+	});
+	it("reads the activity id off the payload without fetching agentActivity", async () => {
+		let agentActivityReads = 0;
+		createAgentActivity.mockResolvedValue({
+			success: true,
+			agentActivityId: "activity-7",
+			get agentActivity() {
+				agentActivityReads++;
+				return Promise.resolve({ id: "activity-7" });
+			},
+		});
+
+		const issueTracker = {
+			createAgentActivity,
+		} as unknown as IIssueTrackerService;
+		const activityId = await poster.postActivityDirect(
+			issueTracker,
+			{
+				agentSessionId: "session-1",
+				content: { type: "thought", body: "thinking" },
+			},
+			"thought activity",
+		);
+
+		expect(activityId).toBe("activity-7");
+		expect(agentActivityReads).toBe(0);
+	});
+
+	it("returns null without fetching agentActivity when the payload carries no id", async () => {
+		let agentActivityReads = 0;
+		createAgentActivity.mockResolvedValue({
+			success: true,
+			get agentActivity() {
+				agentActivityReads++;
+				return Promise.resolve({ id: "activity-8" });
+			},
+		});
+
+		const issueTracker = {
+			createAgentActivity,
+		} as unknown as IIssueTrackerService;
+		const activityId = await poster.postActivityDirect(
+			issueTracker,
+			{
+				agentSessionId: "session-1",
+				content: { type: "thought", body: "thinking" },
+			},
+			"thought activity",
+		);
+
+		expect(activityId).toBeNull();
+		expect(agentActivityReads).toBe(0);
 	});
 });

--- a/packages/edge-worker/test/LinearActivitySink.test.ts
+++ b/packages/edge-worker/test/LinearActivitySink.test.ts
@@ -49,7 +49,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -71,7 +71,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-2" }),
+				agentActivityId: "activity-2",
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -91,7 +91,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-3" }),
+				agentActivityId: "activity-3",
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -107,7 +107,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-4" }),
+				agentActivityId: "activity-4",
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -123,7 +123,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-5" }),
+				agentActivityId: "activity-5",
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -145,7 +145,7 @@ describe("LinearActivitySink", () => {
 			);
 		});
 
-		it("should return empty result when success but no agentActivity", async () => {
+		it("should return empty result when success but no agentActivityId", async () => {
 			const activity: AgentActivityContent = {
 				type: "thought",
 				body: "Test",
@@ -153,7 +153,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: undefined,
+				agentActivityId: undefined,
 			} as any);
 
 			const result = await sink.postActivity(mockSessionId, activity);
@@ -184,7 +184,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity);
@@ -201,7 +201,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-eph" }),
+				agentActivityId: "activity-eph",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, options);
@@ -225,7 +225,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-sig" }),
+				agentActivityId: "activity-sig",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, options);
@@ -246,7 +246,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-sel" }),
+				agentActivityId: "activity-sel",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, { signal: "select" });
@@ -266,7 +266,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-stop" }),
+				agentActivityId: "activity-stop",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, { signal: "stop" });
@@ -286,7 +286,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-cont" }),
+				agentActivityId: "activity-cont",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, {
@@ -309,7 +309,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-meta" }),
+				agentActivityId: "activity-meta",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, {
@@ -333,7 +333,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-no-eph" }),
+				agentActivityId: "activity-no-eph",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity, {});
@@ -350,7 +350,7 @@ describe("LinearActivitySink", () => {
 			const expectedSessionId = "new-session-123";
 			vi.mocked(mockIssueTracker.createAgentSessionOnIssue).mockResolvedValue({
 				success: true,
-				agentSession: Promise.resolve({ id: expectedSessionId }),
+				agentSessionId: expectedSessionId,
 			} as any);
 
 			const sessionId = await sink.createAgentSession(mockIssueId);
@@ -364,7 +364,7 @@ describe("LinearActivitySink", () => {
 		it("should throw when result.success is false", async () => {
 			vi.mocked(mockIssueTracker.createAgentSessionOnIssue).mockResolvedValue({
 				success: false,
-				agentSession: Promise.resolve({ id: "should-not-reach" }),
+				agentSessionId: "should-not-reach",
 			} as any);
 
 			await expect(sink.createAgentSession(mockIssueId)).rejects.toThrow(
@@ -383,24 +383,29 @@ describe("LinearActivitySink", () => {
 			);
 		});
 
-		it("should await agentSession promise before extracting ID", async () => {
+		it("should read the id off the payload without fetching agentSession", async () => {
 			const expectedSessionId = "new-session-456";
-			const agentSessionPromise = Promise.resolve({ id: expectedSessionId });
+			let agentSessionReads = 0;
 
 			vi.mocked(mockIssueTracker.createAgentSessionOnIssue).mockResolvedValue({
 				success: true,
-				agentSession: agentSessionPromise,
+				agentSessionId: expectedSessionId,
+				get agentSession() {
+					agentSessionReads++;
+					return Promise.resolve({ id: expectedSessionId });
+				},
 			} as any);
 
 			const sessionId = await sink.createAgentSession(mockIssueId);
 
 			expect(sessionId).toBe(expectedSessionId);
+			expect(agentSessionReads).toBe(0);
 		});
 
 		it("should call createAgentSessionOnIssue exactly once", async () => {
 			vi.mocked(mockIssueTracker.createAgentSessionOnIssue).mockResolvedValue({
 				success: true,
-				agentSession: Promise.resolve({ id: "session-123" }),
+				agentSessionId: "session-123",
 			} as any);
 
 			await sink.createAgentSession(mockIssueId);
@@ -415,7 +420,7 @@ describe("LinearActivitySink", () => {
 		it("should handle multiple activity posts to the same session", async () => {
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, {
@@ -438,7 +443,7 @@ describe("LinearActivitySink", () => {
 		it("should handle creating multiple sessions", async () => {
 			vi.mocked(mockIssueTracker.createAgentSessionOnIssue).mockResolvedValue({
 				success: true,
-				agentSession: Promise.resolve({ id: "session-1" }),
+				agentSessionId: "session-1",
 			} as any);
 
 			await sink.createAgentSession("issue-1");
@@ -474,7 +479,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, {
@@ -495,7 +500,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity);
@@ -514,7 +519,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity);
@@ -534,7 +539,7 @@ describe("LinearActivitySink", () => {
 
 			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
 				success: true,
-				agentActivity: Promise.resolve({ id: "activity-1" }),
+				agentActivityId: "activity-1",
 			} as any);
 
 			await sink.postActivity(mockSessionId, activity);
@@ -543,6 +548,29 @@ describe("LinearActivitySink", () => {
 				agentSessionId: mockSessionId,
 				content: activity,
 			});
+		});
+	});
+
+	describe("Linear API request amplification", () => {
+		it("should not touch the agentActivity getter when posting an activity", async () => {
+			let agentActivityReads = 0;
+
+			vi.mocked(mockIssueTracker.createAgentActivity).mockResolvedValue({
+				success: true,
+				agentActivityId: "activity-1",
+				get agentActivity() {
+					agentActivityReads++;
+					return Promise.resolve({ id: "activity-1" });
+				},
+			} as any);
+
+			const result = await sink.postActivity(mockSessionId, {
+				type: "thought",
+				body: "Analyzing...",
+			});
+
+			expect(result).toEqual({ activityId: "activity-1" });
+			expect(agentActivityReads).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
## Problem

Posting one agent activity costs **three** Linear API requests instead of one.

`AgentActivityPayload.agentActivity` is a Linear SDK **getter that issues a fresh
`agentActivity(id:)` query on every access**:

```js
get agentActivity() {
    return new AgentActivityQuery(this._request).fetch(this._agentActivity.id);
}
get agentActivityId() {
    return this._agentActivity?.id;   // already in the mutation response, free
}
```

Both activity call sites read that getter purely to obtain `.id`:

- `ActivityPoster.postActivityDirect()` — the `if (result.agentActivity)`
  truthiness test fires one query, and the following `await result.agentActivity`
  fires a second. So: 1 mutation + 2 queries.
- `LinearActivitySink.postActivity()` — same pattern, 1 mutation + 2 queries.
- `LinearActivitySink.createAgentSession()` — same shape via
  `AgentSessionPayload.agentSession`, once per session.

Activities are posted several times per tool call (thoughts, actions,
responses), so a session multiplies its own Linear API consumption by roughly 3.
On a self-hosted deployment, a single ~2 hour agent session of ~800 tool calls
exhausted the workspace's hourly Linear request quota on its own. Past that
point Linear rejects further requests, and because most Linear calls in Cyrus are
wrapped in `catch → log → return null`, the session degrades silently: activity
posts vanish, issue reads come back empty, and the session appears hung rather
than failed. In one observed 6-hour window a self-hosted instance logged 28,266
rate-limit events.

Related: #1325 (reducing the *volume* of activities posted). This PR is the
narrower, purely mechanical part — it changes no behaviour and posts no fewer
activities, it just stops paying two extra requests for an id the response
already contains. #1324 covers *resilience* when the limit is hit anyway.

## Fix

Read the ids off the mutation payload:

- `result.agentActivityId` instead of `await result.agentActivity`
- `result.agentSessionId` instead of `await result.agentSession`

`IssueTrackerAgentSessionPayload` gains the `agentSessionId` field its own doc
comment already referenced (`console.log('Created session:', result.agentSessionId)`),
and `CLIIssueTrackerService` populates both ids on the payloads it synthesizes so
non-Linear trackers take the same path.

Net effect: 3 requests per activity → 1. No functional change; the ids returned
are identical.

## Tests

`pnpm test:run` in `packages/edge-worker`, `test/ActivityPoster.test.ts` and
`test/LinearActivitySink.test.ts` — 35 passed.

Added three regression tests that mock the payload the way the SDK actually
behaves: `agentActivity` / `agentSession` as **getters that count their own
accesses**, asserting the count stays at 0. That fails on the old code, so the
amplification cannot come back unnoticed.

Existing tests were updated to the payload shape (`agentActivityId: "…"` in place
of `agentActivity: Promise.resolve({ id: "…" })`).

## Verification

```
pnpm build                 all packages Done
pnpm typecheck             16/16 projects Done
biome check <changed>      Checked 14 files, no fixes applied
```

`packages/edge-worker` full suite, same machine, before and after:

| | Tests |
|---|---|
| `main` | 50 failed, 699 passed (749) |
| this branch | 50 failed, 702 passed (752) |

Identical failure set — the 50 pre-existing failures are all POSIX-path
assumptions in `GitService` and the prompt-assembly suites failing on a Windows
dev box, in files this PR does not touch. The delta is exactly the 3 tests added
here.

Not verified: I have not exercised this against the live Linear API. The
request-count reduction is derived from the SDK's getter implementation quoted
above, not measured end-to-end.
