### PR TITLE
fix(linear): retry rate-limited Linear requests with bounded backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Rate-limited Linear requests (HTTP 429) are now retried with bounded backoff, honouring the `Retry-After` Linear sends, instead of failing the in-flight agent session. Token-authenticated clients, which previously had no retry at all, are covered too. ([#1324](https://github.com/cyrusagents/cyrus/issues/1324))
 - EdgeWorker state saves are now atomic, preventing a process interrupted during a save from leaving a truncated state file that strands in-flight sessions; empty and legacy-truncated state files also recover cleanly. Thanks @connor-tembo for the contribution. ([CYPACK-1486](https://linear.app/ceedar/issue/CYPACK-1486/can-you-add-a-changelog-entry-for-this), [#1444](https://github.com/cyrusagents/cyrus/pull/1444))
 
 ### Changed

--- a/packages/linear-event-transport/src/LinearIssueTrackerService.ts
+++ b/packages/linear-event-transport/src/LinearIssueTrackerService.ts
@@ -52,6 +52,10 @@ import type {
 } from "cyrus-core";
 import { createLogger, type ILogger } from "cyrus-core";
 import { LinearEventTransport } from "./LinearEventTransport.js";
+import {
+	describeGraphQLOperation,
+	withLinearRateLimitRetry,
+} from "./rateLimitRetry.js";
 
 /**
  * Linear implementation of IIssueTrackerService.
@@ -117,16 +121,21 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 			);
 		}
 
-		// Only patch if oauthConfig is provided AND linearClient.client exists
-		// (the .client property may not exist in test mocks)
-		if (oauthConfig && linearClient.client) {
+		// Patch the transport whenever the underlying GraphQL client exists (the
+		// .client property may not exist in test mocks): rate-limit backoff on the
+		// outside, 401 token refresh (only when oauthConfig is provided) on the
+		// inside.
+		if (linearClient.client) {
 			const client = linearClient.client;
 			const originalRequest = client.request.bind(client);
 
 			// Track the current refresh promise - coalesces concurrent 401 errors.
 			// Cleared when refresh fails or when setAccessToken() is called.
 
-			client.request = async <Data, Variables extends Record<string, unknown>>(
+			const requestWithTokenRefresh = async <
+				Data,
+				Variables extends Record<string, unknown>,
+			>(
 				document: string,
 				variables?: Variables,
 				requestHeaders?: RequestInit["headers"],
@@ -139,9 +148,11 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 						requestHeaders,
 					)) as Data;
 				} catch (error) {
-					// Don't retry if this is already a retry attempt (prevents infinite loops)
+					// Don't retry if this is already a retry attempt (prevents infinite loops),
+					// if there is no OAuth config to refresh with,
 					// or if it's not a token expiration error
-					if (isRetry || !this.isTokenExpiredError(error)) throw error;
+					if (isRetry || !this.oauthConfig || !this.isTokenExpiredError(error))
+						throw error;
 
 					// Coalesce concurrent refresh attempts - everyone shares the same promise.
 					if (!this.refreshPromise) {
@@ -162,12 +173,12 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 						this.refreshPromise = null;
 						client.setHeader("Authorization", `Bearer ${newToken}`);
 
-						// Retry the request with the new token (marked as retry to prevent loops)
-						return (await (client.request as any)(
+						// Retry with the new token via originalRequest, so the retry does not
+						// re-enter this wrapper (and does not start a nested backoff budget).
+						return (await originalRequest(
 							document,
 							variables,
 							requestHeaders,
-							true, // isRetry flag
 						)) as Data;
 					} catch (_refreshError) {
 						// If refresh failed, throw the original 401 error for clarity
@@ -175,6 +186,26 @@ export class LinearIssueTrackerService implements IIssueTrackerService {
 					}
 				}
 			};
+
+			client.request = <Data, Variables extends Record<string, unknown>>(
+				document: string,
+				variables?: Variables,
+				requestHeaders?: RequestInit["headers"],
+				isRetry = false,
+			): Promise<Data> =>
+				withLinearRateLimitRetry(
+					() =>
+						requestWithTokenRefresh<Data, Variables>(
+							document,
+							variables,
+							requestHeaders,
+							isRetry,
+						),
+					{
+						logger: this.logger,
+						operationName: describeGraphQLOperation(document),
+					},
+				);
 		}
 	}
 

--- a/packages/linear-event-transport/src/index.ts
+++ b/packages/linear-event-transport/src/index.ts
@@ -5,6 +5,12 @@ export {
 	type LinearOAuthConfig,
 } from "./LinearIssueTrackerService.js";
 export { LinearMessageTranslator } from "./LinearMessageTranslator.js";
+export {
+	getLinearRetryAfterMs,
+	isLinearRateLimitError,
+	type LinearRateLimitRetryOptions,
+	withLinearRateLimitRetry,
+} from "./rateLimitRetry.js";
 export type {
 	LinearEventTransportConfig,
 	LinearEventTransportEvents,

--- a/packages/linear-event-transport/src/rateLimitRetry.ts
+++ b/packages/linear-event-transport/src/rateLimitRetry.ts
@@ -1,0 +1,199 @@
+/**
+ * Bounded retry with backoff for Linear API rate limiting (HTTP 429).
+ *
+ * Linear allows a fixed number of requests per hour per token. When that budget
+ * is spent the API rejects further requests with a `Ratelimited` error, and the
+ * SDK parses the response's `Retry-After` header into
+ * `RatelimitedLinearError.retryAfter` (seconds). Nothing read that value, so a
+ * single 429 propagated straight to the caller — which, for most Linear calls in
+ * Cyrus, means a logged error and a `null` return. In-flight agent sessions
+ * silently lost activity posts, issue reads, and in the worst case the initial
+ * prompt.
+ *
+ * A 429 is a *pre-execution* rejection: the API declines the request before
+ * applying it, so no mutation is partially applied and retrying cannot
+ * double-post. Only rate-limit errors are retried here; everything else
+ * propagates untouched.
+ *
+ * Waiting is bounded deliberately. A hung session is worse than a failed one, so
+ * if the wait Linear asks for exceeds `maxDelayMs`, or the cumulative wait would
+ * exceed `maxTotalDelayMs`, the error is rethrown immediately rather than parked.
+ *
+ * @module rateLimitRetry
+ */
+
+import { LinearErrorType } from "@linear/sdk";
+import type { ILogger } from "cyrus-core";
+
+/** Total attempts, including the first one. */
+const DEFAULT_MAX_ATTEMPTS = 4;
+/** Base delay for exponential backoff when Linear sends no `Retry-After`. */
+const DEFAULT_BASE_DELAY_MS = 1_000;
+/** Longest single wait. A longer `Retry-After` than this fails fast instead. */
+const DEFAULT_MAX_DELAY_MS = 30_000;
+/** Longest cumulative wait across all attempts for one request. */
+const DEFAULT_MAX_TOTAL_DELAY_MS = 60_000;
+/** Upper bound on the random jitter added to a `Retry-After` derived delay. */
+const RETRY_AFTER_JITTER_MS = 1_000;
+
+export interface LinearRateLimitRetryOptions {
+	/** Total attempts including the first. Default 4 (i.e. up to 3 retries). */
+	maxAttempts?: number;
+	/** Base delay for exponential backoff when no `Retry-After` is present. */
+	baseDelayMs?: number;
+	/** Longest single wait; a larger required wait rethrows instead. */
+	maxDelayMs?: number;
+	/** Longest cumulative wait for one request before giving up. */
+	maxTotalDelayMs?: number;
+	/** Label used in log lines, e.g. the GraphQL operation name. */
+	operationName?: string;
+	logger?: ILogger;
+	/** Injectable for tests. */
+	random?: () => number;
+	/** Injectable for tests. */
+	sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * True when the error is Linear's rate-limit rejection.
+ *
+ * Matches on the SDK's parsed `type` and on HTTP 429, because Linear also
+ * reports rate limiting through GraphQL `errors` on an HTTP 200 response.
+ */
+export function isLinearRateLimitError(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+
+	const candidate = error as {
+		type?: unknown;
+		status?: unknown;
+		response?: { status?: unknown };
+		errors?: Array<{ type?: unknown }>;
+	};
+
+	if (candidate.type === LinearErrorType.Ratelimited) return true;
+	if (candidate.status === 429 || candidate.response?.status === 429)
+		return true;
+
+	return Boolean(
+		candidate.errors?.some(
+			(graphqlError) => graphqlError?.type === LinearErrorType.Ratelimited,
+		),
+	);
+}
+
+/**
+ * The wait Linear asked for, in milliseconds, if it sent one.
+ *
+ * `RatelimitedLinearError.retryAfter` is in seconds. Values that are absent,
+ * non-finite or negative are treated as "not specified".
+ */
+export function getLinearRetryAfterMs(error: unknown): number | undefined {
+	if (!error || typeof error !== "object") return undefined;
+	const { retryAfter } = error as { retryAfter?: unknown };
+	if (typeof retryAfter !== "number") return undefined;
+	if (!Number.isFinite(retryAfter) || retryAfter < 0) return undefined;
+	return Math.round(retryAfter * 1_000);
+}
+
+/**
+ * How long to wait before the next attempt, or `undefined` to stop retrying.
+ *
+ * Honours `Retry-After` when Linear sends one — as a floor, since waiting less
+ * than asked just burns another request — with a little jitter on top so
+ * concurrent callers do not resume in lockstep. Without `Retry-After` it falls
+ * back to exponential backoff with equal jitter.
+ *
+ * Returns `undefined` when the required wait exceeds `maxDelayMs`, so the caller
+ * fails visibly rather than parking a session for minutes.
+ *
+ * @param attempt - 1-based number of the attempt that just failed
+ */
+export function computeLinearRateLimitDelayMs(
+	attempt: number,
+	error: unknown,
+	options: LinearRateLimitRetryOptions = {},
+): number | undefined {
+	const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+	const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+	const random = options.random ?? Math.random;
+
+	const retryAfterMs = getLinearRetryAfterMs(error);
+	if (retryAfterMs !== undefined) {
+		// Linear told us how long to wait; anything shorter is wasted.
+		if (retryAfterMs > maxDelayMs) return undefined;
+		return retryAfterMs + Math.floor(random() * RETRY_AFTER_JITTER_MS);
+	}
+
+	const exponentialMs = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+	// Equal jitter: half fixed, half random, so retries spread out.
+	return Math.floor(exponentialMs / 2 + random() * (exponentialMs / 2));
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `operation`, retrying it while Linear reports rate limiting.
+ *
+ * Non-rate-limit errors, and rate-limit errors that exhaust the attempt or wait
+ * budget, are rethrown unchanged so existing error handling still sees them.
+ */
+export async function withLinearRateLimitRetry<T>(
+	operation: () => Promise<T>,
+	options: LinearRateLimitRetryOptions = {},
+): Promise<T> {
+	const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+	const maxTotalDelayMs = options.maxTotalDelayMs ?? DEFAULT_MAX_TOTAL_DELAY_MS;
+	const sleep = options.sleep ?? defaultSleep;
+	const label = options.operationName ?? "Linear request";
+
+	let totalDelayMs = 0;
+
+	for (let attempt = 1; ; attempt++) {
+		try {
+			return await operation();
+		} catch (error) {
+			if (!isLinearRateLimitError(error)) throw error;
+
+			if (attempt >= maxAttempts) {
+				options.logger?.error(
+					`${label} rate-limited by Linear and out of retries after ${attempt} attempts`,
+				);
+				throw error;
+			}
+
+			const delayMs = computeLinearRateLimitDelayMs(attempt, error, options);
+			if (delayMs === undefined) {
+				options.logger?.error(
+					`${label} rate-limited by Linear; Retry-After exceeds the retry budget, failing fast`,
+				);
+				throw error;
+			}
+
+			if (totalDelayMs + delayMs > maxTotalDelayMs) {
+				options.logger?.error(
+					`${label} rate-limited by Linear; cumulative backoff would exceed ${maxTotalDelayMs}ms, failing fast`,
+				);
+				throw error;
+			}
+
+			totalDelayMs += delayMs;
+			options.logger?.warn(
+				`${label} rate-limited by Linear; retrying in ${delayMs}ms (attempt ${attempt} of ${maxAttempts})`,
+			);
+			await sleep(delayMs);
+		}
+	}
+}
+
+/**
+ * Best-effort operation name from a GraphQL document, for log lines.
+ *
+ * Falls back to a generic label rather than logging a whole query body — these
+ * lines are emitted on the failure path, where a multi-kilobyte document in the
+ * log is worse than no name at all.
+ */
+export function describeGraphQLOperation(document: string): string {
+	const match = /\b(?:query|mutation)\s+(\w+)/.exec(document);
+	return match ? `Linear ${match[1]}` : "Linear request";
+}

--- a/packages/linear-event-transport/test/LinearIssueTrackerService.rateLimit.test.ts
+++ b/packages/linear-event-transport/test/LinearIssueTrackerService.rateLimit.test.ts
@@ -1,0 +1,170 @@
+import type { LinearClient } from "@linear/sdk";
+import { LinearErrorType } from "@linear/sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LinearIssueTrackerService } from "../src/LinearIssueTrackerService.js";
+
+function rateLimitError(retryAfter?: number): Error {
+	const error = new Error(
+		"Rate limit exceeded. Only 5000 requests are allowed per 1 hour.",
+	) as Error & { type: string; retryAfter?: number; status: number };
+	error.type = LinearErrorType.Ratelimited;
+	error.status = 429;
+	if (retryAfter !== undefined) error.retryAfter = retryAfter;
+	return error;
+}
+
+function unauthorizedError(): Error {
+	const error = new Error("Unauthorized") as Error & { status: number };
+	error.status = 401;
+	return error;
+}
+
+/**
+ * Minimal stand-in for the SDK's GraphQL client: just the `request`/`setHeader`
+ * surface that LinearIssueTrackerService patches.
+ */
+function fakeLinearClient(request: ReturnType<typeof vi.fn>) {
+	const setHeader = vi.fn();
+	const client = { request, setHeader };
+	return {
+		linearClient: { client } as unknown as LinearClient,
+		client,
+		setHeader,
+	};
+}
+
+const logger = {
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+
+describe("LinearIssueTrackerService rate-limit handling", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	/** Runs `promise` to completion, letting the backoff timers fire instantly. */
+	async function runWithTimers<T>(promise: Promise<T>): Promise<T> {
+		const settled = promise.then(
+			(value) => ({ ok: true as const, value }),
+			(error) => ({ ok: false as const, error }),
+		);
+		await vi.runAllTimersAsync();
+		const result = await settled;
+		if (!result.ok) throw result.error;
+		return result.value;
+	}
+
+	it("retries a rate-limited request even with no OAuth config", async () => {
+		const request = vi
+			.fn()
+			.mockRejectedValueOnce(rateLimitError(1))
+			.mockResolvedValue({ ok: true });
+		const { linearClient, client } = fakeLinearClient(request);
+
+		new LinearIssueTrackerService(linearClient, undefined, logger as never);
+
+		const result = await runWithTimers(
+			client.request("query agentActivity { id }"),
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("eventually rethrows the rate-limit error so callers still see a failure", async () => {
+		const error = rateLimitError(1);
+		const request = vi.fn().mockRejectedValue(error);
+		const { linearClient, client } = fakeLinearClient(request);
+
+		new LinearIssueTrackerService(linearClient, undefined, logger as never);
+
+		await expect(
+			runWithTimers(client.request("query agentActivity { id }")),
+		).rejects.toBe(error);
+		expect(request).toHaveBeenCalledTimes(4);
+	});
+
+	it("does not retry non-rate-limit errors", async () => {
+		const error = new Error("boom");
+		const request = vi.fn().mockRejectedValue(error);
+		const { linearClient, client } = fakeLinearClient(request);
+
+		new LinearIssueTrackerService(linearClient, undefined, logger as never);
+
+		await expect(
+			runWithTimers(client.request("query agentActivity { id }")),
+		).rejects.toBe(error);
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+
+	it("still refreshes the token on 401 when OAuth config is supplied", async () => {
+		const request = vi
+			.fn()
+			.mockRejectedValueOnce(unauthorizedError())
+			.mockResolvedValue({ ok: true });
+		const { linearClient, client, setHeader } = fakeLinearClient(request);
+
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				access_token: "lin_oauth_new",
+				refresh_token: "refresh_new",
+				expires_in: 3600,
+			}),
+		} as unknown as Response);
+
+		new LinearIssueTrackerService(
+			linearClient,
+			{
+				clientId: "client-id",
+				clientSecret: "client-secret",
+				refreshToken: "refresh-old",
+				workspaceId: `workspace-${Math.random()}`,
+			},
+			logger as never,
+		);
+
+		const result = await runWithTimers(
+			client.request("query agentActivity { id }"),
+		);
+
+		expect(result).toEqual({ ok: true });
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(setHeader).toHaveBeenCalledWith(
+			"Authorization",
+			"Bearer lin_oauth_new",
+		);
+		expect(request).toHaveBeenCalledTimes(2);
+
+		fetchSpy.mockRestore();
+	});
+
+	it("does not attempt a token refresh for a rate-limit error", async () => {
+		const request = vi
+			.fn()
+			.mockRejectedValueOnce(rateLimitError(1))
+			.mockResolvedValue({ ok: true });
+		const { linearClient, client } = fakeLinearClient(request);
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		new LinearIssueTrackerService(
+			linearClient,
+			{
+				clientId: "client-id",
+				clientSecret: "client-secret",
+				refreshToken: "refresh-old",
+				workspaceId: `workspace-${Math.random()}`,
+			},
+			logger as never,
+		);
+
+		await runWithTimers(client.request("query agentActivity { id }"));
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		fetchSpy.mockRestore();
+	});
+});

--- a/packages/linear-event-transport/test/rateLimitRetry.test.ts
+++ b/packages/linear-event-transport/test/rateLimitRetry.test.ts
@@ -1,0 +1,252 @@
+import { LinearErrorType } from "@linear/sdk";
+import { describe, expect, it, vi } from "vitest";
+import {
+	computeLinearRateLimitDelayMs,
+	describeGraphQLOperation,
+	getLinearRetryAfterMs,
+	isLinearRateLimitError,
+	withLinearRateLimitRetry,
+} from "../src/rateLimitRetry.js";
+
+/** Shaped like the Linear SDK's RatelimitedLinearError. */
+function rateLimitError(retryAfter?: number): Error {
+	const error = new Error(
+		"Rate limit exceeded. Only 5000 requests are allowed per 1 hour.",
+	) as Error & { type: string; retryAfter?: number; status: number };
+	error.type = LinearErrorType.Ratelimited;
+	error.status = 429;
+	if (retryAfter !== undefined) error.retryAfter = retryAfter;
+	return error;
+}
+
+/** Collects sleeps instead of performing them, so tests stay instant. */
+function fakeSleep() {
+	const slept: number[] = [];
+	return {
+		slept,
+		sleep: async (ms: number) => {
+			slept.push(ms);
+		},
+	};
+}
+
+describe("isLinearRateLimitError", () => {
+	it("recognises the SDK's parsed Ratelimited type", () => {
+		expect(isLinearRateLimitError(rateLimitError())).toBe(true);
+	});
+
+	it("recognises a bare HTTP 429", () => {
+		expect(isLinearRateLimitError({ status: 429 })).toBe(true);
+		expect(isLinearRateLimitError({ response: { status: 429 } })).toBe(true);
+	});
+
+	it("recognises rate limiting reported through GraphQL errors on HTTP 200", () => {
+		expect(
+			isLinearRateLimitError({
+				errors: [{ type: LinearErrorType.Ratelimited }],
+			}),
+		).toBe(true);
+	});
+
+	it("does not treat other failures as rate limiting", () => {
+		expect(isLinearRateLimitError(new Error("boom"))).toBe(false);
+		expect(isLinearRateLimitError({ status: 401 })).toBe(false);
+		expect(
+			isLinearRateLimitError({ type: LinearErrorType.AuthenticationError }),
+		).toBe(false);
+		expect(isLinearRateLimitError(undefined)).toBe(false);
+		expect(isLinearRateLimitError("Ratelimited")).toBe(false);
+	});
+});
+
+describe("getLinearRetryAfterMs", () => {
+	it("converts retryAfter seconds to milliseconds", () => {
+		expect(getLinearRetryAfterMs(rateLimitError(2))).toBe(2_000);
+		expect(getLinearRetryAfterMs(rateLimitError(0))).toBe(0);
+	});
+
+	it("ignores absent or nonsensical values", () => {
+		expect(getLinearRetryAfterMs(rateLimitError())).toBeUndefined();
+		expect(getLinearRetryAfterMs(rateLimitError(-1))).toBeUndefined();
+		expect(
+			getLinearRetryAfterMs(rateLimitError(Number.POSITIVE_INFINITY)),
+		).toBeUndefined();
+	});
+});
+
+describe("computeLinearRateLimitDelayMs", () => {
+	it("honours Retry-After as a floor and adds jitter", () => {
+		const delay = computeLinearRateLimitDelayMs(1, rateLimitError(3), {
+			random: () => 0.5,
+		});
+
+		expect(delay).toBe(3_000 + 500);
+	});
+
+	it("refuses to retry when Retry-After exceeds the single-wait cap", () => {
+		const delay = computeLinearRateLimitDelayMs(1, rateLimitError(3_600), {
+			maxDelayMs: 30_000,
+		});
+
+		expect(delay).toBeUndefined();
+	});
+
+	it("backs off exponentially with jitter when Retry-After is absent", () => {
+		const options = { baseDelayMs: 1_000, random: () => 1 };
+
+		expect(computeLinearRateLimitDelayMs(1, rateLimitError(), options)).toBe(
+			1_000,
+		);
+		expect(computeLinearRateLimitDelayMs(2, rateLimitError(), options)).toBe(
+			2_000,
+		);
+		expect(computeLinearRateLimitDelayMs(3, rateLimitError(), options)).toBe(
+			4_000,
+		);
+	});
+
+	it("keeps exponential jitter within half the computed delay", () => {
+		const low = computeLinearRateLimitDelayMs(3, rateLimitError(), {
+			baseDelayMs: 1_000,
+			random: () => 0,
+		});
+
+		expect(low).toBe(2_000);
+	});
+
+	it("caps exponential backoff at maxDelayMs", () => {
+		const delay = computeLinearRateLimitDelayMs(10, rateLimitError(), {
+			baseDelayMs: 1_000,
+			maxDelayMs: 5_000,
+			random: () => 1,
+		});
+
+		expect(delay).toBe(5_000);
+	});
+});
+
+describe("withLinearRateLimitRetry", () => {
+	it("returns the result without sleeping when the call succeeds", async () => {
+		const { slept, sleep } = fakeSleep();
+		const operation = vi.fn().mockResolvedValue("ok");
+
+		await expect(withLinearRateLimitRetry(operation, { sleep })).resolves.toBe(
+			"ok",
+		);
+		expect(operation).toHaveBeenCalledTimes(1);
+		expect(slept).toEqual([]);
+	});
+
+	it("retries a rate-limited call and returns the eventual success", async () => {
+		const { slept, sleep } = fakeSleep();
+		const operation = vi
+			.fn()
+			.mockRejectedValueOnce(rateLimitError(2))
+			.mockResolvedValue("ok");
+
+		await expect(
+			withLinearRateLimitRetry(operation, { sleep, random: () => 0 }),
+		).resolves.toBe("ok");
+		expect(operation).toHaveBeenCalledTimes(2);
+		expect(slept).toEqual([2_000]);
+	});
+
+	it("gives up after maxAttempts and rethrows the original error", async () => {
+		const { slept, sleep } = fakeSleep();
+		const error = rateLimitError(1);
+		const operation = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			withLinearRateLimitRetry(operation, {
+				sleep,
+				random: () => 0,
+				maxAttempts: 3,
+			}),
+		).rejects.toBe(error);
+		expect(operation).toHaveBeenCalledTimes(3);
+		expect(slept).toEqual([1_000, 1_000]);
+	});
+
+	it("does not retry non-rate-limit errors", async () => {
+		const { slept, sleep } = fakeSleep();
+		const error = new Error("boom");
+		const operation = vi.fn().mockRejectedValue(error);
+
+		await expect(withLinearRateLimitRetry(operation, { sleep })).rejects.toBe(
+			error,
+		);
+		expect(operation).toHaveBeenCalledTimes(1);
+		expect(slept).toEqual([]);
+	});
+
+	it("fails fast rather than parking a session for a long Retry-After", async () => {
+		const { slept, sleep } = fakeSleep();
+		const error = rateLimitError(3_600);
+		const operation = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			withLinearRateLimitRetry(operation, { sleep, maxDelayMs: 30_000 }),
+		).rejects.toBe(error);
+		expect(operation).toHaveBeenCalledTimes(1);
+		expect(slept).toEqual([]);
+	});
+
+	it("stops once the cumulative wait budget would be exceeded", async () => {
+		const { slept, sleep } = fakeSleep();
+		const error = rateLimitError(20);
+		const operation = vi.fn().mockRejectedValue(error);
+
+		await expect(
+			withLinearRateLimitRetry(operation, {
+				sleep,
+				random: () => 0,
+				maxAttempts: 10,
+				maxDelayMs: 30_000,
+				maxTotalDelayMs: 30_000,
+			}),
+		).rejects.toBe(error);
+		// 20s fits the 30s budget; a second 20s does not.
+		expect(slept).toEqual([20_000]);
+		expect(operation).toHaveBeenCalledTimes(2);
+	});
+
+	it("logs each retry and the final give-up", async () => {
+		const { sleep } = fakeSleep();
+		const logger = { warn: vi.fn(), error: vi.fn() };
+		const operation = vi.fn().mockRejectedValue(rateLimitError(1));
+
+		await expect(
+			withLinearRateLimitRetry(operation, {
+				sleep,
+				random: () => 0,
+				maxAttempts: 2,
+				operationName: "Linear agentActivity",
+				logger: logger as never,
+			}),
+		).rejects.toThrow("Rate limit exceeded");
+
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn.mock.calls[0][0]).toContain("Linear agentActivity");
+		expect(logger.error).toHaveBeenCalledTimes(1);
+		expect(logger.error.mock.calls[0][0]).toContain("out of retries");
+	});
+});
+
+describe("describeGraphQLOperation", () => {
+	it("names the operation for the log line", () => {
+		expect(
+			describeGraphQLOperation(
+				"query agentActivity($id: String!) { agentActivity(id: $id) { id } }",
+			),
+		).toBe("Linear agentActivity");
+		expect(
+			describeGraphQLOperation("mutation agentActivityCreate { ok }"),
+		).toBe("Linear agentActivityCreate");
+	});
+
+	it("falls back rather than logging an unnamed document body", () => {
+		expect(describeGraphQLOperation("{ viewer { id } }")).toBe(
+			"Linear request",
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1324.

## Problem

Linear rejects requests over the hourly quota with a `Ratelimited` error. The SDK
already parses the response's `Retry-After` header into
`RatelimitedLinearError.retryAfter` — **nothing reads it**.

All three `LinearClient` constructions pass a bare `{ accessToken }`: no retry,
no middleware. The one place that intercepts the transport
(`LinearIssueTrackerService`) handles **401 only**; a 429 is rethrown
immediately, on the first occurrence.

And then the failure disappears, because almost every Linear call in Cyrus sits
behind `catch → log → return null`. So a rate-limited session does not stop — it
degrades invisibly:

- activity posts are silently lost, so the Linear timeline just stops updating
- issue and comment reads come back empty, and the agent proceeds on missing context
- worst case is at **session start**, where the initial prompt is dropped with
  nothing posted to Linear at all — the session looks hung rather than failed

On a self-hosted deployment this is not theoretical. Measured over one retained
window: **41,742 rate-limit log lines**, 28,266 of them inside a single 6-hour
window, and ~7,844 unhandled promise rejections across four days. Two ~2-hour
agent sessions on the same day both stalled and needed manual intervention — one
sat for over an hour unable to read a comment that had been posted to it, the
other could not post its output at all. Across 1,845,515 log records in an 8-hour
window there were **zero** authentication errors, which rules out token expiry
and leaves the quota as the sole cause.

## Fix

A small `withLinearRateLimitRetry` helper, wrapped around the GraphQL transport.

- **Retries only rate-limit errors.** Everything else propagates untouched, so
  existing error handling is unaffected. Detection covers the SDK's parsed
  `type`, HTTP 429, and rate limiting reported through GraphQL `errors` on an
  HTTP 200 response.
- **Honours `Retry-After` as a floor**, plus a little jitter so concurrent
  callers do not resume in lockstep. Waiting less than Linear asked just burns
  another request. Without the header it falls back to exponential backoff with
  equal jitter.
- **Safe for mutations.** A 429 is a *pre-execution* rejection — Linear declines
  the request without applying it — so a retried `agentActivityCreate` cannot
  double-post. This is why the retry can be transport-level rather than
  hand-placed on read paths only.
- **Bounded on purpose.** A parked session is worse than a failed one: at most 4
  attempts, 30s for any single wait, 60s cumulative. If Linear asks for longer
  than the single-wait cap — an exhausted hourly quota can mean minutes — the
  request **fails fast** rather than sleeping through the session.

The transport patch now installs whenever the underlying GraphQL client exists,
rather than only when OAuth config is supplied. Token-authenticated clients
previously had no retry of any kind, and Linear's quota is per token however that
token was obtained. The 401 refresh path keeps its existing behaviour, but now
retries via `originalRequest` so it no longer re-enters the wrapper or nests a
second backoff budget.

## Tests

`packages/linear-event-transport` — **49 passed (4 files)**, of which 25 are new:

- `test/rateLimitRetry.test.ts` (20) — detection across all three error shapes,
  `Retry-After` parsing, the delay formula (floor, jitter bounds, exponential
  fallback, cap), and the retry loop: success without sleeping, retry then
  succeed, give up and rethrow the original error, never retry non-rate-limit
  errors, fail fast on a long `Retry-After`, stop at the cumulative budget, and
  the log lines.
- `test/LinearIssueTrackerService.rateLimit.test.ts` (5) — the wiring: a
  rate-limited request retries **with no OAuth config** (the case that had no
  retry before), the error is still eventually rethrown after a bounded 4
  attempts, non-rate-limit errors are not retried, 401 refresh still works, and a
  429 does not trigger a spurious token refresh.

Sleep and randomness are injected, so no test waits on real time.

## Verification

```
pnpm build                        all packages Done
pnpm typecheck                    16/16 projects Done
biome check <changed files>       clean
packages/linear-event-transport   49 passed (49)
```

**Designed, not proven end-to-end.** I have not exercised this against a live
Linear API returning real 429s — the retry behaviour is verified against error
objects shaped like `RatelimitedLinearError`, and the `Retry-After` semantics are
taken from the SDK's own `error.d.ts`. Reproducing genuine quota exhaustion
against a real workspace is not something I could do safely.

## Scope

Deliberately excluded:

- **Reducing request volume.** #1325 (config to suppress low-value activity
  posts) and the payload-id fix in #1412 both cut how fast the quota is consumed.
  This PR is only about surviving the limit once it is hit; the three are
  complementary and independent.
- **The swallowed-failure design.** Retries make `catch → log → return null` fire
  far less often, but a genuinely exhausted quota still ends in a silent `null`
  with no indication in Linear. Making Linear-write failures visible to the user
  (and to the session) is a broader change than this PR should carry — happy to
  open a separate issue for it if that would be useful.
- Unbounded session state / #1381 — unrelated subsystem.
