### PR TITLE
chore(deps): update Anthropic SDKs to latest (CYPACK-1455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.205` to [`0.3.237`](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#03237) and `@anthropic-ai/sdk` from `^0.110.0` to [`^0.120.0`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#01200-2026-08-19), restoring `LSP`, adding `ShareOnboardingGuide`, and bringing Claude sessions current with the latest Agent SDK and API capabilities. ([CYPACK-1455](https://linear.app/ceedar/issue/CYPACK-1455/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest), [#1416](https://github.com/cyrusagents/cyrus/pull/1416))
+
 ### Fixed
 - The self-hosted GitHub App setup flow (`cyrus-setup-github` skill, "enable @mentions") no longer fails with "Default events are not supported by permissions: organization". The generated App manifest subscribed to an event with no matching permission, so GitHub rejected the submission and no App was ever created. ([#1406](https://github.com/cyrusagents/cyrus/issues/1406), [#1407](https://github.com/cyrusagents/cyrus/pull/1407))
 

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -21,8 +21,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.205",
-		"@anthropic-ai/sdk": "^0.110.0",
+		"@anthropic-ai/claude-agent-sdk": "0.3.237",
+		"@anthropic-ai/sdk": "^0.120.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -44,6 +44,7 @@ export const availableTools = [
 	// User interaction tools
 	"SendMessage",
 	"PushNotification",
+	"ShareOnboardingGuide",
 
 	// Plan and worktree management
 	"EnterWorktree",
@@ -57,6 +58,7 @@ export const availableTools = [
 
 	// Monitoring and task lifecycle
 	"Monitor",
+	"LSP",
 	"RemoteTrigger",
 	"TaskOutput",
 	"TaskStop",
@@ -92,6 +94,8 @@ export const readOnlyTools: ToolName[] = [
 	"Task",
 	"Skill",
 	"Monitor",
+	"LSP",
+	"ShareOnboardingGuide",
 	"TaskOutput",
 	"ToolSearch",
 ];

--- a/packages/claude-runner/test/config.test.ts
+++ b/packages/claude-runner/test/config.test.ts
@@ -29,6 +29,7 @@ describe("config", () => {
 				"Skill",
 				"SendMessage",
 				"PushNotification",
+				"ShareOnboardingGuide",
 				"EnterWorktree",
 				"ExitWorktree",
 				"CronCreate",
@@ -36,6 +37,7 @@ describe("config", () => {
 				"CronList",
 				"ScheduleWakeup",
 				"Monitor",
+				"LSP",
 				"RemoteTrigger",
 				"TaskOutput",
 				"TaskStop",
@@ -44,7 +46,7 @@ describe("config", () => {
 				"Workflow",
 				"ReportFindings",
 			]);
-			expect(availableTools).toHaveLength(29);
+			expect(availableTools).toHaveLength(31);
 		});
 
 		it("should define read-only tools", () => {
@@ -59,10 +61,12 @@ describe("config", () => {
 				"Task",
 				"Skill",
 				"Monitor",
+				"LSP",
+				"ShareOnboardingGuide",
 				"TaskOutput",
 				"ToolSearch",
 			]);
-			expect(readOnlyTools).toHaveLength(12);
+			expect(readOnlyTools).toHaveLength(14);
 		});
 
 		it("should define write tools", () => {

--- a/packages/codex-runner/src/CodexEventMapper.ts
+++ b/packages/codex-runner/src/CodexEventMapper.ts
@@ -163,6 +163,7 @@ function emptyUsageBlock(): SDKAssistantMessage["message"]["usage"] {
 		output_tokens: 0,
 		cache_creation_input_tokens: 0,
 		cache_read_input_tokens: 0,
+		fallback_credit: null,
 		output_tokens_details: null,
 		cache_creation: null,
 		inference_geo: null,
@@ -246,6 +247,9 @@ function createResultUsage(parsed: NormalizedUsage): SDKResultMessage["usage"] {
 		output_tokens: parsed.output_tokens,
 		cache_creation_input_tokens: 0,
 		cache_read_input_tokens: parsed.cached_input_tokens,
+		fallback_credit: {
+			status: { type: "not_applied", reason: "not_enabled" },
+		},
 		output_tokens_details: { thinking_tokens: 0 },
 		cache_creation: {
 			ephemeral_1h_input_tokens: 0,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.205",
+		"@anthropic-ai/claude-agent-sdk": "0.3.237",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/core/src/allowed-tools-defaults.ts
+++ b/packages/core/src/allowed-tools-defaults.ts
@@ -50,6 +50,7 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	// User interaction
 	"SendMessage",
 	"PushNotification",
+	"ShareOnboardingGuide",
 
 	// Task lifecycle
 	"TaskCreate",
@@ -67,6 +68,7 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 
 	// Monitoring + discovery
 	"Monitor",
+	"LSP",
 	"RemoteTrigger",
 	"ToolSearch",
 	"Skill",
@@ -168,6 +170,7 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	// User interaction
 	"SendMessage",
 	"PushNotification",
+	"ShareOnboardingGuide",
 
 	// Task lifecycle
 	"TaskCreate",
@@ -185,6 +188,7 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 
 	// Monitoring + discovery
 	"Monitor",
+	"LSP",
 	"RemoteTrigger",
 	"ToolSearch",
 	"Skill",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -28,7 +28,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.205",
+		"@anthropic-ai/claude-agent-sdk": "0.3.237",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/gemini-runner/src/GeminiRunner.ts
+++ b/packages/gemini-runner/src/GeminiRunner.ts
@@ -458,6 +458,9 @@ export class GeminiRunner extends EventEmitter implements IAgentRunner {
 					output_tokens: 0,
 					cache_creation_input_tokens: 0,
 					cache_read_input_tokens: 0,
+					fallback_credit: {
+						status: { type: "not_applied", reason: "not_enabled" },
+					},
 					cache_creation: {
 						ephemeral_1h_input_tokens: 0,
 						ephemeral_5m_input_tokens: 0,

--- a/packages/gemini-runner/src/adapters.ts
+++ b/packages/gemini-runner/src/adapters.ts
@@ -44,6 +44,7 @@ function createBetaMessage(
 			output_tokens: 0,
 			cache_creation_input_tokens: 0,
 			cache_read_input_tokens: 0,
+			fallback_credit: null,
 			output_tokens_details: null,
 			cache_creation: null,
 			inference_geo: null,
@@ -227,6 +228,9 @@ export function geminiEventToSDKMessage(
 						output_tokens: stats.output_tokens || 0,
 						cache_creation_input_tokens: 0,
 						cache_read_input_tokens: 0,
+						fallback_credit: {
+							status: { type: "not_applied", reason: "not_enabled" },
+						},
 						cache_creation: {
 							ephemeral_1h_input_tokens: 0,
 							ephemeral_5m_input_tokens: 0,
@@ -264,6 +268,9 @@ export function geminiEventToSDKMessage(
 						output_tokens: stats.output_tokens || 0,
 						cache_creation_input_tokens: 0,
 						cache_read_input_tokens: 0,
+						fallback_credit: {
+							status: { type: "not_applied", reason: "not_enabled" },
+						},
 						cache_creation: {
 							ephemeral_1h_input_tokens: 0,
 							ephemeral_5m_input_tokens: 0,
@@ -304,6 +311,9 @@ export function geminiEventToSDKMessage(
 					output_tokens: 0,
 					cache_creation_input_tokens: 0,
 					cache_read_input_tokens: 0,
+					fallback_credit: {
+						status: { type: "not_applied", reason: "not_enabled" },
+					},
 					cache_creation: {
 						ephemeral_1h_input_tokens: 0,
 						ephemeral_5m_input_tokens: 0,

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -21,7 +21,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.205",
+		"@anthropic-ai/claude-agent-sdk": "0.3.237",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,11 +147,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.205
-        version: 0.3.205(@anthropic-ai/sdk@0.110.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.237
+        version: 0.3.237(@anthropic-ai/sdk@0.120.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.110.0
-        version: 0.110.0(zod@4.3.6)
+        specifier: ^0.120.0
+        version: 0.120.0(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -253,8 +253,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.205
-        version: 0.3.205(@anthropic-ai/sdk@0.110.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.237
+        version: 0.3.237(@anthropic-ai/sdk@0.120.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -303,8 +303,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.205
-        version: 0.3.205(@anthropic-ai/sdk@0.110.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.237
+        version: 0.3.237(@anthropic-ai/sdk@0.120.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -525,8 +525,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.205
-        version: 0.3.205(@anthropic-ai/sdk@0.110.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.237
+        version: 0.3.237(@anthropic-ai/sdk@0.120.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -565,60 +565,60 @@ importers:
 
 packages:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.205':
-    resolution: {integrity: sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.237':
+    resolution: {integrity: sha512-u9r73eYFatAT5h9ntX2Mx6v+4pe3+7mIQYnljf7MyJnitgnWBrexiNMyc2WxKQpkBNyen8m0dgnO0zCjGnfG1g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.205':
-    resolution: {integrity: sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.237':
+    resolution: {integrity: sha512-M7gmrWLhTLS4p9jRTXktPwMendILa0zD3CeFa22dpYP35tHZJkwPbB2UbZrnYWHV2ws5pZi5lB1rLOsTInvC+Q==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.205':
-    resolution: {integrity: sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.237':
+    resolution: {integrity: sha512-gOe5H4SsL9KWPRn8YoJ0TcekLHU6XvGxPQ692lPq1ZGueYDsSE6LUeojYy1wQc3R0pwwmz2cJU5DtaM4qPa50A==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.205':
-    resolution: {integrity: sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.237':
+    resolution: {integrity: sha512-LTZ1cd1AKDJtNU6tdzYi2UUu8sC9rBfcuL1to1ET92rx8aVzHfF1/f36tkBPqc9PVPVpUhF8nr4Y7F4eild5HQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.205':
-    resolution: {integrity: sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.237':
+    resolution: {integrity: sha512-EfI/AMf75UEDjIsYAYZj1RHXrFLvJXlCyx8gC4M1u1BG1+Qwdc/r3wz7cGYVknWE+8nu9Q+Ik9RMwPnXBPbqLA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.205':
-    resolution: {integrity: sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.237':
+    resolution: {integrity: sha512-CnJokzNI0TTLX75PjsrJM8vtfp5x1lReB0QLMZbSAjPRbPudeeZr5Gs2rwB9X63CXvHaTKOrt74TUPgMA3na0A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.205':
-    resolution: {integrity: sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.237':
+    resolution: {integrity: sha512-5cKVKcjWSJ9iFDDj7UaiJ+N0GC1NGZC0Z3Z1K+wXW8uy4nWSe0bHpo5S95HypOwuHUENSjlmvv++xv9l6nPj3Q==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205':
-    resolution: {integrity: sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.237':
+    resolution: {integrity: sha512-DvHNDIFgx/jpRuGqKDedeK3zmaBzjmDz7dM1Vh/nzaJYuyLwK7uzh+Lc88o6wfRlRzvH1jOstetqKqol+BxuRw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.205':
-    resolution: {integrity: sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw==}
+  '@anthropic-ai/claude-agent-sdk@0.3.237':
+    resolution: {integrity: sha512-MVjJ+13YP5uzA3WcCrtDmEirPcwdVsJjTGn/WbUtcXh0Y40KzcG5QocEo4x+QXl5eQ9kKIoDtcjIAfAAauXfeA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': '>=1.30.0'
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.110.0':
-    resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
+  '@anthropic-ai/sdk@0.120.0':
+    resolution: {integrity: sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2775,46 +2775,46 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.205':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.237':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.205(@anthropic-ai/sdk@0.110.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.237(@anthropic-ai/sdk@0.120.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.110.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.120.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.205
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.205
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.237
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.237
 
-  '@anthropic-ai/sdk@0.110.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.120.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0

--- a/scripts/extract-claude-tools.sh
+++ b/scripts/extract-claude-tools.sh
@@ -56,7 +56,7 @@ echo "Using SDK CLI: $CLI_PATH"
 echo "Running Claude Code to capture init block..."
 # Capture full output to a temp file to avoid SIGPIPE from head -1
 # (pipefail + head causes claude to exit non-zero when the pipe closes early)
-tmpfile=$(mktemp)
+tmpfile=$(mktemp "${TMPDIR:-/tmp}/claude-tools.XXXXXX")
 trap 'rm -f "$tmpfile"' EXIT
 "$CLI_PATH" -p "say hi" --output-format stream-json --verbose 2>/dev/null > "$tmpfile" || true
 


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- Updates `@anthropic-ai/claude-agent-sdk` from `0.3.205` to `0.3.237` and `@anthropic-ai/sdk` from `^0.110.0` to `^0.120.0`.
- Refreshes the live-extracted Claude Code tool catalog with `LSP` and `ShareOnboardingGuide`, while retaining task tools explicitly after SDK 0.3.233 removed them from the default surface.
- Adapts synthetic Codex/Gemini usage messages to the SDK's required `fallback_credit` field and makes tool extraction honor `TMPDIR`.

## Test release

- Published `cyrus-claude-runner@0.2.69-test.1` under the `test` tag.
- Published `cyrus-core@0.2.69-test.1` under the `test` tag.
- Verified both packages leave `latest` unchanged at `0.2.68`.

## Verification

- `pnpm build`
- `pnpm test:packages:run` (1,609 passed, 1 skipped)
- `pnpm --filter cyrus-ai test` (102 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm audit` (zero advisories)
- `./scripts/extract-claude-tools.sh`

Related: [CYPACK-1455](https://linear.app/ceedar/issue/CYPACK-1455/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest)
Hosted companion: [cyrus-hosted#1034](https://github.com/cyrusagents/cyrus-hosted/pull/1034)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
