### PR TITLE
fix(cli): stop check-tokens hanging forever and falsely reporting tokens dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- `cyrus check-tokens` no longer hangs forever. The command finished its work but the process never exited (Node's global `fetch` keeps keep-alive sockets that hold the event loop open), so it piled up orphaned processes and, when an uptime monitor shelled out to it, timed out and falsely reported a healthy Linear token as dead. The command now exits explicitly with a meaningful status code, bounds each token check with an internal timeout, and reports an unreachable network as "unknown" rather than "invalid".
+- `cyrus check-tokens` no longer hangs forever. The command finished its work but the process never exited (Node's global `fetch` keeps keep-alive sockets that hold the event loop open), so it piled up orphaned processes and, when an uptime monitor shelled out to it, timed out and falsely reported a healthy Linear token as dead. The command now exits explicitly with a meaningful status code, bounds each token check with an internal timeout, and reports an unreachable network as "unknown" rather than "invalid". ([#1419](https://github.com/cyrusagents/cyrus/pull/1419))
 - The self-hosted GitHub App setup flow (`cyrus-setup-github` skill, "enable @mentions") no longer fails with "Default events are not supported by permissions: organization". The generated App manifest subscribed to an event with no matching permission, so GitHub rejected the submission and no App was ever created. ([#1406](https://github.com/cyrusagents/cyrus/issues/1406), [#1407](https://github.com/cyrusagents/cyrus/pull/1407))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- `cyrus check-tokens` no longer hangs forever. The command finished its work but the process never exited (Node's global `fetch` keeps keep-alive sockets that hold the event loop open), so it piled up orphaned processes and, when an uptime monitor shelled out to it, timed out and falsely reported a healthy Linear token as dead. The command now exits explicitly with a meaningful status code, bounds each token check with an internal timeout, and reports an unreachable network as "unknown" rather than "invalid".
 - The self-hosted GitHub App setup flow (`cyrus-setup-github` skill, "enable @mentions") no longer fails with "Default events are not supported by permissions: organization". The generated App manifest subscribed to an event with no matching permission, so GitHub rejected the submission and no App was ever created. ([#1406](https://github.com/cyrusagents/cyrus/issues/1406), [#1407](https://github.com/cyrusagents/cyrus/pull/1407))
 
 ### Security

--- a/apps/cli/src/commands/CheckTokensCommand.test.ts
+++ b/apps/cli/src/commands/CheckTokensCommand.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	checkLinearToken,
+	TOKEN_CHECK_TIMEOUT_MS,
+} from "./CheckTokensCommand.js";
+
+describe("checkLinearToken", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		vi.useRealTimers();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it("returns valid when Linear responds without errors", async () => {
+		globalThis.fetch = vi.fn(async () => ({
+			json: async () => ({ data: { viewer: { id: "u1" } } }),
+		})) as unknown as typeof fetch;
+
+		const result = await checkLinearToken("lin_oauth_good");
+		expect(result).toEqual({ status: "valid" });
+	});
+
+	it("returns invalid when Linear rejects the token", async () => {
+		globalThis.fetch = vi.fn(async () => ({
+			json: async () => ({
+				errors: [{ message: "Authentication required, not authenticated" }],
+			}),
+		})) as unknown as typeof fetch;
+
+		const result = await checkLinearToken("lin_oauth_bad");
+		expect(result).toEqual({
+			status: "invalid",
+			error: "Authentication required, not authenticated",
+		});
+	});
+
+	it("returns unknown (not invalid) on a network-level failure", async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new TypeError("fetch failed");
+		}) as unknown as typeof fetch;
+
+		const result = await checkLinearToken("lin_oauth_whatever");
+		// A network failure must NOT be reported as an invalid/dead token —
+		// that false signal is what made the uptime monitor cry wolf.
+		expect(result.status).toBe("unknown");
+		expect(result).not.toHaveProperty("status", "invalid");
+	});
+
+	it("returns unknown on timeout instead of hanging forever", async () => {
+		// Simulate an endpoint that never responds: fetch rejects with an
+		// AbortError once the AbortController fires. This asserts the command
+		// resolves (does not hang) and classifies the timeout as unknown.
+		globalThis.fetch = vi.fn((_url: unknown, init: unknown) => {
+			const signal = (init as { signal?: AbortSignal } | undefined)?.signal;
+			return new Promise((_resolve, reject) => {
+				signal?.addEventListener("abort", () => {
+					const err = new Error("The operation was aborted");
+					err.name = "AbortError";
+					reject(err);
+				});
+			});
+		}) as unknown as typeof fetch;
+
+		vi.useFakeTimers();
+		const promise = checkLinearToken("lin_oauth_slow");
+		// Advance past the internal timeout so the AbortController fires.
+		await vi.advanceTimersByTimeAsync(TOKEN_CHECK_TIMEOUT_MS + 1);
+		const result = await promise;
+
+		expect(result.status).toBe("unknown");
+		if (result.status === "unknown") {
+			expect(result.error).toContain("Timed out");
+		}
+	});
+});

--- a/apps/cli/src/commands/CheckTokensCommand.ts
+++ b/apps/cli/src/commands/CheckTokensCommand.ts
@@ -1,11 +1,37 @@
 import { BaseCommand } from "./ICommand.js";
 
 /**
- * Helper function to check Linear token status
+ * Maximum time (ms) to wait for the Linear API to respond before treating the
+ * check as "could not determine". Without this bound a slow or unreachable
+ * endpoint would hang the `await fetch(...)` indefinitely, and the whole
+ * command would never return.
  */
-async function checkLinearToken(
+export const TOKEN_CHECK_TIMEOUT_MS = 15_000;
+
+/** Result of checking a single token. */
+export type TokenCheckResult =
+	| { status: "valid" }
+	| { status: "invalid"; error: string }
+	/**
+	 * The check could not be completed (network error, timeout, unexpected
+	 * response). This is explicitly NOT the same as an invalid token — the
+	 * token may well be fine; we simply could not reach Linear to confirm.
+	 */
+	| { status: "unknown"; error: string };
+
+/**
+ * Helper function to check Linear token status.
+ *
+ * Uses an AbortController so a slow/blocked endpoint can never hang the
+ * command — on timeout the check resolves to `unknown` rather than blocking
+ * forever or masquerading as an invalid token.
+ */
+export async function checkLinearToken(
 	token: string,
-): Promise<{ valid: boolean; error?: string }> {
+): Promise<TokenCheckResult> {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TOKEN_CHECK_TIMEOUT_MS);
+
 	try {
 		const response = await fetch("https://api.linear.app/graphql", {
 			method: "POST",
@@ -16,25 +42,49 @@ async function checkLinearToken(
 			body: JSON.stringify({
 				query: "{ viewer { id email name } }",
 			}),
+			signal: controller.signal,
 		});
 
 		const data = (await response.json()) as any;
 
 		if (data.errors) {
 			return {
-				valid: false,
+				status: "invalid",
 				error: data.errors[0]?.message || "Unknown error",
 			};
 		}
 
-		return { valid: true };
+		return { status: "valid" };
 	} catch (error) {
-		return { valid: false, error: (error as Error).message };
+		if ((error as Error).name === "AbortError") {
+			return {
+				status: "unknown",
+				error: `Timed out after ${TOKEN_CHECK_TIMEOUT_MS}ms`,
+			};
+		}
+		// A network-level failure (DNS, connection refused, TLS, etc.) means we
+		// could not determine the token's validity — not that it is invalid.
+		return { status: "unknown", error: (error as Error).message };
+	} finally {
+		clearTimeout(timeout);
 	}
 }
 
 /**
- * Check tokens command - check the status of all Linear tokens
+ * Check tokens command - check the status of all Linear tokens.
+ *
+ * Exit codes:
+ *   0 - every configured token was validated successfully.
+ *   1 - at least one token was rejected by Linear (genuinely invalid).
+ *   2 - at least one token could not be checked (network error / timeout) and
+ *       none were rejected — the caller should treat this as "unknown", not
+ *       "dead".
+ *
+ * The command always exits explicitly. Node's global `fetch` keeps HTTP
+ * keep-alive sockets in a connection pool that keep the event loop alive, so
+ * without an explicit `process.exit` the process would linger after the checks
+ * completed. Exiting deterministically also lets monitors distinguish an
+ * invalid token from an unreachable network.
  */
 export class CheckTokensCommand extends BaseCommand {
 	async execute(_args: string[]): Promise<void> {
@@ -46,6 +96,9 @@ export class CheckTokensCommand extends BaseCommand {
 		const config = this.app.config.load();
 
 		console.log("Checking Linear tokens...\n");
+
+		let anyInvalid = false;
+		let anyUnknown = false;
 
 		// Check tokens at the workspace level
 		const checkedWorkspaces = new Set<string>();
@@ -62,15 +115,26 @@ export class CheckTokensCommand extends BaseCommand {
 			process.stdout.write(`Workspace ${workspaceName}: `);
 			if (!token) {
 				console.log(`❌ No token configured`);
+				anyInvalid = true;
 				continue;
 			}
 			const result = await checkLinearToken(token);
 
-			if (result.valid) {
+			if (result.status === "valid") {
 				console.log("✅ Valid");
-			} else {
+			} else if (result.status === "invalid") {
 				console.log(`❌ Invalid - ${result.error}`);
+				anyInvalid = true;
+			} else {
+				console.log(`⚠️  Unknown (could not check) - ${result.error}`);
+				anyUnknown = true;
 			}
 		}
+
+		// Exit explicitly so lingering keep-alive sockets from `fetch` can't keep
+		// the event loop alive and hang the command. An invalid token takes
+		// precedence over an unknown one so a genuine failure is never masked.
+		const exitCode = anyInvalid ? 1 : anyUnknown ? 2 : 0;
+		process.exit(exitCode);
 	}
 }


### PR DESCRIPTION
## Summary

`cyrus check-tokens` hangs forever and never returns. This was found operating a live Cyrus deployment: running the installed binary under a 45s hard timeout produced its output and then never exited (it was killed by SIGTERM). Over ~6 days it piled up 10+ orphaned `node cyrus check-tokens` process trees.

Worse, an uptime monitor shells out to `cyrus check-tokens` and waits for it. Because the command hangs, the monitor's own timeout fires, and it then **falsely reports the Linear OAuth token as "dead"** — when the token is actually fine (webhooks flow and agents spawn normally). A false "token dead" page is worse than no check.

## Root cause

`CheckTokensCommand.execute()` finishes its work and returns, but the **process never exits because open handles keep the event loop alive**. `checkLinearToken()` uses Node's global `fetch` (undici), which keeps HTTP keep-alive sockets in a connection pool after the response is read; those sockets (together with the always-initialized Sentry error reporter) keep the event loop from draining, so the CLI lingers instead of exiting. There was also no timeout on the `await fetch(...)`, so a genuinely slow or unreachable endpoint could block the command outright — and a network failure was reported identically to an invalid token, which is exactly what let a network hang masquerade as a dead token.

## Fix

In `apps/cli/src/commands/CheckTokensCommand.ts`:

- **Terminate deterministically.** After all checks complete, the command now `process.exit()`s with a meaningful status code so lingering keep-alive sockets can never keep it alive:
  - `0` — every configured token validated successfully
  - `1` — at least one token was rejected by Linear (genuinely invalid)
  - `2` — at least one token could not be checked (network error / timeout) and none were rejected → **unknown**, not dead
- **Bound each check with an internal timeout.** An `AbortController` aborts the `fetch` after 15s, so a slow/blocked endpoint can never hang the command.
- **Stop network failures masquerading as dead tokens.** Network errors and timeouts are now classified `unknown` (exit 2, distinct message) instead of `invalid`, so a network hang no longer trips a false "token dead" alert. Invalid takes precedence over unknown so a real failure is never masked.
- Added unit tests covering the valid / invalid / network-error / timeout paths.

The behavior change is purely in the exit path and error classification; the happy-path output ("Valid" / "Invalid - ...") is unchanged, with a new "Unknown (could not check) - ..." line for the network-failure case.

## Verification

Run from the built CLI against a config with a dummy invalid token, under a 45s hard timeout (the same repro that originally hung):

```
$ timeout --signal=TERM 45 node apps/cli/dist/src/app.js --cyrus-home <fake> check-tokens
Checking Linear tokens...

Workspace FakeWorkspace: Invalid - Authentication required, not authenticated
=== EXIT CODE: 1  ELAPSED: 2s ===
```

It now exits in ~2s with a meaningful code instead of being killed at 45s. (Note the pre-fix handler returned exit code `0` even for an invalid token, so the monitor could not distinguish states via exit code either.)

- `pnpm --filter cyrus-ai typecheck` -> clean (exit 0)
- `pnpm lint` (Biome) -> no errors on the changed files
- `pnpm --filter cyrus-ai test:run` -> **106 passed** (including 4 new tests for the timeout/unknown classification)
- `pnpm build` -> succeeds

Found operating a live Cyrus deployment.
