### PR TITLE
fix(edge-worker): distinguish a cancelled AskUserQuestion from a declined one

### DIFF
--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -91,11 +91,29 @@ export type AskUserQuestionAnswers = Record<string, string>;
  * Result of presenting questions to the user.
  */
 export interface AskUserQuestionResult {
-	/** Whether the user provided answers (true) or the request was cancelled/denied (false) */
+	/** Whether the user provided answers (true) or not (false) */
 	answered: boolean;
 	/** The user's answers, if answered is true */
 	answers?: AskUserQuestionAnswers;
-	/** Message explaining why the request was denied, if answered is false */
+	/**
+	 * True when the question never reached a human — aborted, replaced by a
+	 * later question, the session ended, or the elicitation could not be posted.
+	 *
+	 * This is deliberately distinct from a human seeing the question and
+	 * declining. Both produce `answered: false`, but they mean opposite things:
+	 * a decline is a decision, whereas a cancellation is the *absence* of one.
+	 * Collapsing them lets an agent read "nobody answered" as tacit approval and
+	 * carry on, which is worse than never having asked — the thread then reads
+	 * as though a human signed off.
+	 */
+	cancelled?: boolean;
+	/**
+	 * Explains why no answer was obtained, when `answered` is false.
+	 *
+	 * This string is surfaced to the model, so for cancellations it must say
+	 * plainly that the question was not answered and must not be treated as
+	 * approval. See {@link cancelled}.
+	 */
 	message?: string;
 }
 

--- a/packages/edge-worker/src/AskUserQuestionHandler.ts
+++ b/packages/edge-worker/src/AskUserQuestionHandler.ts
@@ -94,6 +94,32 @@ export class AskUserQuestionHandler {
 	 * @param signal - AbortSignal for cancellation
 	 * @returns Promise resolving to the user's answer or denial
 	 */
+	/**
+	 * Build the result for a question that never reached a human.
+	 *
+	 * Every one of these paths previously returned a bare `answered: false` with a
+	 * terse reason, which is the same shape a human declining would produce. The
+	 * model receives only this object, so "replaced by a newer question" and "the
+	 * user said no" were indistinguishable — and the absence of an answer reads as
+	 * permission to continue. Observed in the wild: an agent asked whether to
+	 * proceed, the question was cancelled unanswered, and the agent shipped the
+	 * work anyway, leaving a Linear thread that looks like it was approved.
+	 *
+	 * The message is deliberately explicit rather than terse, because it is the
+	 * only part of this the model actually reads.
+	 */
+	private notAnswered(reason: string): AskUserQuestionResult {
+		return {
+			answered: false,
+			cancelled: true,
+			message:
+				`NOT ANSWERED — ${reason}. No human saw or responded to this question. ` +
+				"This is not approval and must not be treated as one. Do not proceed as " +
+				"though the question was answered; stop and report that you could not " +
+				"obtain a decision.",
+		};
+	}
+
 	async handleAskUserQuestion(
 		input: AskUserQuestionInput,
 		linearAgentSessionId: string,
@@ -105,11 +131,10 @@ export class AskUserQuestionHandler {
 			this.logger.error(
 				`Invalid input: expected exactly 1 question, got ${input.questions?.length ?? 0}`,
 			);
-			return {
-				answered: false,
-				message:
-					"Only one question at a time is supported. Please ask each question separately.",
-			};
+			return this.notAnswered(
+				"only one question at a time is supported, and this call contained " +
+					`${input.questions?.length ?? 0}; ask each question separately`,
+			);
 		}
 
 		const question = input.questions[0]!;
@@ -119,10 +144,9 @@ export class AskUserQuestionHandler {
 
 		// Check if already cancelled
 		if (signal.aborted) {
-			return {
-				answered: false,
-				message: "Operation was cancelled",
-			};
+			return this.notAnswered(
+				"the session was aborted before the question was posted",
+			);
 		}
 
 		// Get issue tracker
@@ -131,10 +155,9 @@ export class AskUserQuestionHandler {
 			this.logger.error(
 				`No issue tracker found for organization ${organizationId}`,
 			);
-			return {
-				answered: false,
-				message: "Issue tracker not available",
-			};
+			return this.notAnswered(
+				"no issue tracker is available for this organization, so the question could not be posted",
+			);
 		}
 
 		// Check for existing pending question for this session
@@ -144,7 +167,7 @@ export class AskUserQuestionHandler {
 			);
 			this.cancelPendingQuestion(
 				linearAgentSessionId,
-				"Replaced by new question",
+				"it was replaced by a newer question on the same session",
 			);
 		}
 
@@ -182,10 +205,9 @@ export class AskUserQuestionHandler {
 		} catch (error) {
 			const errorMessage = (error as Error).message || String(error);
 			this.logger.error(`Failed to post elicitation: ${errorMessage}`);
-			return {
-				answered: false,
-				message: `Failed to present question to user: ${errorMessage}`,
-			};
+			return this.notAnswered(
+				`the elicitation could not be posted to Linear (${errorMessage})`,
+			);
 		}
 
 		// Create promise to wait for user response
@@ -197,10 +219,11 @@ export class AskUserQuestionHandler {
 					`Question cancelled for session ${linearAgentSessionId}`,
 				);
 				this.pendingQuestions.delete(linearAgentSessionId);
-				resolve({
-					answered: false,
-					message: "Operation was cancelled",
-				});
+				resolve(
+					this.notAnswered(
+						"the session was cancelled while the question was open",
+					),
+				);
 			};
 			signal.addEventListener("abort", abortHandler, { once: true });
 
@@ -281,10 +304,7 @@ export class AskUserQuestionHandler {
 			this.logger.debug(
 				`Cancelling pending question for session ${linearAgentSessionId}: ${reason}`,
 			);
-			pendingQuestion.resolve({
-				answered: false,
-				message: reason,
-			});
+			pendingQuestion.resolve(this.notAnswered(reason));
 		}
 	}
 

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -4788,10 +4788,11 @@ ${taskSection}`;
 			this.logger.warn(
 				"Cannot handle AskUserQuestion response without agentActivity",
 			);
-			// Resolve with a denial to unblock the waiting promise
+			// Unblock the waiting promise. Note this is a cancellation, not a
+			// denial: nobody saw the question, so the result must not read as one.
 			this.askUserQuestionHandler.cancelPendingQuestion(
 				agentSessionId,
-				"No agent activity in webhook",
+				"the webhook carried no agent activity, so no response could be read",
 			);
 			return;
 		}

--- a/packages/edge-worker/test/AskUserQuestionHandler.test.ts
+++ b/packages/edge-worker/test/AskUserQuestionHandler.test.ts
@@ -48,8 +48,9 @@ describe("AskUserQuestionHandler", () => {
 			);
 
 			expect(result.answered).toBe(false);
+			expect(result.cancelled).toBe(true);
 			expect(result.message).toContain(
-				"Only one question at a time is supported",
+				"only one question at a time is supported",
 			);
 		});
 
@@ -86,8 +87,9 @@ describe("AskUserQuestionHandler", () => {
 			);
 
 			expect(result.answered).toBe(false);
+			expect(result.cancelled).toBe(true);
 			expect(result.message).toContain(
-				"Only one question at a time is supported",
+				"only one question at a time is supported",
 			);
 			// Should not have called createAgentActivity
 			expect(mockCreateAgentActivity).not.toHaveBeenCalled();
@@ -118,7 +120,8 @@ describe("AskUserQuestionHandler", () => {
 			);
 
 			expect(result.answered).toBe(false);
-			expect(result.message).toBe("Operation was cancelled");
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("NOT ANSWERED");
 		});
 
 		it("should reject if issue tracker is not available", async () => {
@@ -149,7 +152,8 @@ describe("AskUserQuestionHandler", () => {
 			);
 
 			expect(result.answered).toBe(false);
-			expect(result.message).toBe("Issue tracker not available");
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("no issue tracker is available");
 		});
 	});
 
@@ -353,7 +357,8 @@ describe("AskUserQuestionHandler", () => {
 
 			const result = await resultPromise;
 			expect(result.answered).toBe(false);
-			expect(result.message).toBe("Operation was cancelled");
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("the session was cancelled");
 		});
 
 		it("should resolve with custom message when cancelPendingQuestion is called", async () => {
@@ -387,7 +392,92 @@ describe("AskUserQuestionHandler", () => {
 
 			const result = await resultPromise;
 			expect(result.answered).toBe(false);
-			expect(result.message).toBe("Custom cancellation reason");
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("Custom cancellation reason");
+		});
+	});
+
+	describe("cancellation is distinguishable from a decline", () => {
+		const q: AskUserQuestionInput = {
+			questions: [
+				{
+					question: "Ship it?",
+					header: "Ship",
+					options: [{ label: "Yes", description: "Proceed" }],
+					multiSelect: false,
+				},
+			],
+		};
+
+		it("marks every unanswered outcome as cancelled, and says so in the message", async () => {
+			const ac = new AbortController();
+			const pending = handler.handleAskUserQuestion(
+				q,
+				"s1",
+				"org-123",
+				ac.signal,
+			);
+			await new Promise((r) => setTimeout(r, 10));
+			handler.cancelPendingQuestion("s1", "the session ended");
+			const result = await pending;
+
+			expect(result.answered).toBe(false);
+			expect(result.cancelled).toBe(true);
+			// The message is the only part the model reads, so it must rule out
+			// the reading that caused this bug: silence as consent.
+			expect(result.message).toContain("not approval");
+			expect(result.message).toContain("the session ended");
+		});
+
+		it("does NOT mark a genuine answer as cancelled", async () => {
+			const ac = new AbortController();
+			const pending = handler.handleAskUserQuestion(
+				q,
+				"s2",
+				"org-123",
+				ac.signal,
+			);
+			await new Promise((r) => setTimeout(r, 10));
+			handler.handleUserResponse("s2", "Yes");
+			const result = await pending;
+
+			expect(result.answered).toBe(true);
+			// Control: if `cancelled` were set unconditionally the assertion above
+			// would still pass, so an answered result must explicitly not carry it.
+			expect(result.cancelled).toBeFalsy();
+		});
+
+		it("marks a replaced question as cancelled rather than declined", async () => {
+			const ac = new AbortController();
+			const first = handler.handleAskUserQuestion(
+				q,
+				"s3",
+				"org-123",
+				ac.signal,
+			);
+			await new Promise((r) => setTimeout(r, 10));
+			// Deliberately not awaited: the second question stays pending by design,
+			// so awaiting it would hang. It is the *first* promise under test.
+			void handler.handleAskUserQuestion(q, "s3", "org-123", ac.signal);
+			const result = await first;
+
+			expect(result.answered).toBe(false);
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("replaced by a newer question");
+		});
+
+		it("marks a rejected multi-question call as cancelled", async () => {
+			const ac = new AbortController();
+			const result = await handler.handleAskUserQuestion(
+				{ questions: [q.questions[0]!, q.questions[0]!] },
+				"s4",
+				"org-123",
+				ac.signal,
+			);
+
+			expect(result.answered).toBe(false);
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("not approval");
 		});
 	});
 
@@ -436,7 +526,8 @@ describe("AskUserQuestionHandler", () => {
 			// First should be cancelled
 			const result1 = await resultPromise1;
 			expect(result1.answered).toBe(false);
-			expect(result1.message).toBe("Replaced by new question");
+			expect(result1.cancelled).toBe(true);
+			expect(result1.message).toContain("replaced by a newer question");
 
 			// Clean up second
 			await new Promise((resolve) => setTimeout(resolve, 10));
@@ -472,7 +563,8 @@ describe("AskUserQuestionHandler", () => {
 			);
 
 			expect(result.answered).toBe(false);
-			expect(result.message).toContain("Failed to present question");
+			expect(result.cancelled).toBe(true);
+			expect(result.message).toContain("could not be posted to Linear");
 			expect(result.message).toContain("API Error");
 		});
 	});


### PR DESCRIPTION
## The problem

`AskUserQuestionResult` collapses two opposite outcomes into one shape. A user seeing a question and **declining**, and a question that **never reached a human at all**, both return `answered: false` with a terse reason:

```ts
// cancelPendingQuestion — "Replaced by new question", "Operation was cancelled", …
pendingQuestion.resolve({ answered: false, message: reason });
```

The model receives only this object. So *"replaced by a newer question"* and *"the user said no"* are indistinguishable — and the absence of an answer reads as permission to continue.

The type's own doc has the same conflation: `message` is described as explaining why the request was **"denied"**.

## What it looks like in production

We hit this on a real task. An agent asked whether to proceed, the options were posted to Linear, the question was cancelled unanswered, and the agent **shipped the work anyway** ~19 minutes later.

The output was good, but it had asked for consent and proceeded without it. That's worse than never asking: the Linear thread now reads as though a human approved it. We first tried to fix it with an instruction in the agent's rules telling it never to ask from a subagent and to treat "not answered" as stop. It recurred on the next task, with the rule loaded and in force 1.5 hours earlier — which is what convinced us it needs to be a property of the result, not advice.

## The change

Adds `cancelled?: boolean`, set on every path where no human answered:

| path | `answered` | `cancelled` |
| -- | -- | -- |
| user responds | `true` | — |
| aborted before posting | `false` | `true` |
| cancelled while open | `false` | `true` |
| replaced by a later question | `false` | `true` |
| elicitation failed to post | `false` | `true` |
| no issue tracker | `false` | `true` |
| multi-question rejection | `false` | `true` |

The `message` is now explicit rather than terse, since it's the only part the model actually reads — it states the question was not answered, that this is not approval, and that the agent should stop and report rather than proceed.

This is additive: `cancelled` is optional and nothing existing reads it.

## Deliberately left alone

**Pending questions remain keyed by Linear agent session.** A parent and its subagents still share one slot, so a second question still cancels the first. Notably `createAskUserQuestionCallback` receives the Claude session id and discards it — that's what would disambiguate them:

```ts
return async (input, _sessionId, signal) => {
  // Note: We use linearAgentSessionId (from closure) instead of the passed sessionId
  return this.askUserQuestionHandler.handleAskUserQuestion(input, linearAgentSessionId, …);
};
```

Keying by both would permit concurrent questions per session — a behavioural change deserving its own PR. This fix makes the collision *honest* in the meantime rather than silent. Happy to follow up if you'd want that.

## Tests

The existing suite asserted the old literal strings, so those assertions now check the new contract. Four cases added covering cancelled-vs-answered, replacement, and the multi-question rejection — including a **control** that an answered result does not carry `cancelled`, without which the assertions would pass against a flag set unconditionally.

Verified:
- `tsc --noEmit` clean, `biome check` clean
- edge-worker suite: **753 passing**
- both mutations fail the new tests — removing the flag → 11 failures, reverting the message → 3 — so they aren't vacuous