### PR TITLE
Make strict MCP config configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added an enabled-by-default `strictMcpConfig` setting for Claude sessions. Set it to `false` to make ambient MCP sources—including authenticated claude.ai connectors, project and user settings, and plugins—available alongside Cyrus-configured servers; config reloads and pre-warmed sessions honor changes. ([CYHOST-1245](https://linear.app/ceedar/issue/CYHOST-1245/can-u-add-a-bevahiours-settings-page-setting-for-strict-mcp-config), [#1434](https://github.com/cyrusagents/cyrus/pull/1434))
 - OpenCode is now a supported Cyrus runner for self-hosted sessions, including `opencode` labels and `[agent=opencode]` selectors, provider/model defaults, runtime config overrides, MCP and tool permission translation, CLI-managed auth/state handling, readable Linear activity, session resume/follow-up handling, and stalled-runner recovery. Thanks @JappyMondo and @jappyjan for the original contribution. ([CYPACK-1466](https://linear.app/ceedar/issue/CYPACK-1466/create-clean-opencode-support-pr-from-pr-1263-tip), [#1426](https://github.com/cyrusagents/cyrus/pull/1426))
 
 ### Changed

--- a/packages/claude-runner/src/ClaudeRunner.ts
+++ b/packages/claude-runner/src/ClaudeRunner.ts
@@ -716,15 +716,10 @@ export class ClaudeRunner extends EventEmitter implements IAgentRunner {
 					}),
 					...(Object.keys(mcpServers).length > 0 && { mcpServers }),
 					// Only use MCP servers we explicitly pass via `mcpConfig` /
-					// `mcpServers`. The flag is undertyped in the SDK's TS
-					// definition (described as "strict validation") but Claude
-					// Code's `--strict-mcp-config` CLI help is unambiguous:
-					// "Only use MCP servers from --mcp-config, ignoring all
-					// other MCP configurations." That's the contract we want
-					// for hosted sessions — never silently inherit servers
-					// from the user's `~/.claude.json`, project `.mcp.json`,
-					// or other ambient sources.
-					strictMcpConfig: true,
+					// `mcpServers` by default. Operators may opt out to let Claude
+					// Code also load project/user settings, plugins, and authenticated
+					// claude.ai connectors.
+					strictMcpConfig: this.config.strictMcpConfig ?? true,
 					hooks: this.buildHooksWithPendingWorkRecorder(),
 					...(this.config.plugins?.length && { plugins: this.config.plugins }),
 					...(this.config.skills !== undefined && {

--- a/packages/claude-runner/src/types.ts
+++ b/packages/claude-runner/src/types.ts
@@ -44,6 +44,12 @@ export interface ClaudeRunnerConfig {
 	appendSystemPrompt?: string; // Additional prompt to append to the default system prompt
 	mcpConfigPath?: string | string[]; // Single path or array of paths to compose
 	mcpConfig?: Record<string, McpServerConfig>; // Additional/override MCP servers
+	/**
+	 * Only use MCP servers explicitly supplied by Cyrus. When false, Claude Code
+	 * may also load project/user MCP settings, plugins, and authenticated
+	 * claude.ai connectors. Defaults to true.
+	 */
+	strictMcpConfig?: boolean;
 	model?: string; // Claude model to use (e.g., "opus", "sonnet", "haiku")
 	fallbackModel?: string; // Fallback model if primary model is unavailable
 	maxTurns?: number; // Maximum number of turns before completing the session

--- a/packages/claude-runner/test/ClaudeRunner.test.ts
+++ b/packages/claude-runner/test/ClaudeRunner.test.ts
@@ -142,6 +142,29 @@ describe("ClaudeRunner", () => {
 			});
 		});
 
+		it("should allow ambient MCP configuration when strict mode is disabled", async () => {
+			const nonStrictRunner = new ClaudeRunner({
+				...defaultConfig,
+				strictMcpConfig: false,
+			});
+			mockQuery.mockImplementation(async function* () {
+				yield {
+					type: "assistant",
+					message: { content: [{ type: "text", text: "Hello!" }] },
+					parent_tool_use_id: null,
+					session_id: "test-session",
+				} as any;
+			});
+
+			await nonStrictRunner.start("test");
+
+			expect(mockQuery).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({ strictMcpConfig: false }),
+				}),
+			);
+		});
+
 		it("should handle workspace configuration properly", async () => {
 			const runnerWithWorkspace = new ClaudeRunner({
 				...defaultConfig,

--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -647,6 +647,9 @@
 				"type": "string"
 			}
 		},
+		"strictMcpConfig": {
+			"type": "boolean"
+		},
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -641,6 +641,9 @@
 				"type": "string"
 			}
 		},
+		"strictMcpConfig": {
+			"type": "boolean"
+		},
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},

--- a/packages/core/src/agent-runner-types.ts
+++ b/packages/core/src/agent-runner-types.ts
@@ -481,6 +481,11 @@ export interface AgentRunnerConfig {
 	mcpConfigPath?: string | string[];
 	/** MCP server configurations (inline) */
 	mcpConfig?: Record<string, McpServerConfig>;
+	/**
+	 * Whether Claude should use only MCP servers explicitly supplied by Cyrus.
+	 * Defaults to true for Claude sessions.
+	 */
+	strictMcpConfig?: boolean;
 	/** Global OpenCode runtime config overrides from Cyrus config */
 	opencodeGlobalConfig?: JsonObject;
 	/** Repository OpenCode runtime config overrides from Cyrus config */

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -511,6 +511,14 @@ export const EdgeConfigSchema = z.object({
 	githubMcpConfigs: z.array(z.string()).optional(),
 
 	/**
+	 * Restrict Claude sessions to MCP servers explicitly supplied by Cyrus.
+	 * When false, Claude Code may also load servers from project/user settings,
+	 * plugins, and authenticated claude.ai connectors. Defaults to true when
+	 * omitted.
+	 */
+	strictMcpConfig: z.boolean().optional(),
+
+	/**
 	 * Whether to trigger agent sessions when issue title, description, or attachments are updated.
 	 * When enabled, the agent receives context showing what changed (old vs new values).
 	 * Defaults to true if not specified.

--- a/packages/core/test/config-schemas.test.ts
+++ b/packages/core/test/config-schemas.test.ts
@@ -10,6 +10,20 @@ const baseRepository = {
 };
 
 describe("EdgeConfigSchema", () => {
+	it("accepts strict MCP configuration as a top-level boolean", () => {
+		const enabled = EdgeConfigSchema.parse({
+			repositories: [baseRepository],
+			strictMcpConfig: true,
+		});
+		const disabled = EdgeConfigSchema.parse({
+			repositories: [baseRepository],
+			strictMcpConfig: false,
+		});
+
+		expect(enabled.strictMcpConfig).toBe(true);
+		expect(disabled.strictMcpConfig).toBe(false);
+	});
+
 	it("accepts arbitrary JSON-compatible OpenCode config at global and repository levels", () => {
 		const config = {
 			repositories: [

--- a/packages/core/test/json-schema-export.test.ts
+++ b/packages/core/test/json-schema-export.test.ts
@@ -58,6 +58,7 @@ describe("JSON Schema export", () => {
 				"slackMcpConfigs",
 				"linearMcpConfigs",
 				"githubMcpConfigs",
+				"strictMcpConfig",
 				"issueUpdateTrigger",
 				"prReviewTrigger",
 				"userAccessControl",

--- a/packages/edge-worker/src/ChatSessionHandler.ts
+++ b/packages/edge-worker/src/ChatSessionHandler.ts
@@ -108,6 +108,8 @@ export interface ChatSessionHandlerDeps {
 	 * no custom files load (native MCP servers still run as usual).
 	 */
 	getPlatformMcpConfigOverrides?: () => readonly string[] | undefined;
+	/** Live read of whether Claude should ignore ambient MCP configuration. */
+	getStrictMcpConfig?: () => boolean | undefined;
 	/** Resolve managed skill plugins and scoped skill names for a chat session. */
 	resolveSkillsConfig?: (input: {
 		repository?: RepositoryConfig;
@@ -788,6 +790,7 @@ export class ChatSessionHandler<TEvent> {
 			repository,
 			repositoryPaths,
 			platformMcpConfigOverrides: this.deps.getPlatformMcpConfigOverrides?.(),
+			strictMcpConfig: this.deps.getStrictMcpConfig?.(),
 			plugins: skillsConfig.plugins,
 			skills: skillsConfig.skills,
 			opencodeGlobalConfig: this.deps.getOpenCodeGlobalConfig?.(),

--- a/packages/edge-worker/src/ConfigManager.ts
+++ b/packages/edge-worker/src/ConfigManager.ts
@@ -252,6 +252,8 @@ export class ConfigManager extends EventEmitter {
 					parsedConfig.linearMcpConfigs || this.config.linearMcpConfigs,
 				githubMcpConfigs:
 					parsedConfig.githubMcpConfigs || this.config.githubMcpConfigs,
+				strictMcpConfig:
+					parsedConfig.strictMcpConfig ?? this.config.strictMcpConfig,
 				defaultDisallowedTools:
 					parsedConfig.defaultDisallowedTools ||
 					this.config.defaultDisallowedTools,
@@ -365,6 +367,7 @@ export class ConfigManager extends EventEmitter {
 			"slackMcpConfigs",
 			"linearMcpConfigs",
 			"githubMcpConfigs",
+			"strictMcpConfig",
 			"defaultDisallowedTools",
 			"promptDefaults",
 			"issueUpdateTrigger",

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -644,6 +644,15 @@ export class EdgeWorker extends EventEmitter {
 		this.configManager.on(
 			"configChanged",
 			async (changes: RepositoryChanges) => {
+				const strictMcpConfigChanged =
+					(this.config.strictMcpConfig ?? true) !==
+					(changes.newConfig.strictMcpConfig ?? true);
+				if (strictMcpConfigChanged) {
+					for (const warmSession of this.warmInstances.values()) {
+						warmSession.close();
+					}
+					this.warmInstances.clear();
+				}
 				this.updateLinearWorkspaceTokens(changes.newConfig);
 				await this.removeDeletedRepositories(changes.removed);
 				await this.updateModifiedRepositories(changes.modified);
@@ -1109,6 +1118,7 @@ export class EdgeWorker extends EventEmitter {
 				// Live read so hot-reloaded config (`setConfig`) picks up new
 				// per-platform MCP paths without rebuilding the handler.
 				getPlatformMcpConfigOverrides: () => this.config.slackMcpConfigs,
+				getStrictMcpConfig: () => this.config.strictMcpConfig,
 				resolveSkillsConfig: async ({ repository, repositoryPaths }) => {
 					const plugins = await this.skillsPluginResolver.resolve();
 					const skills = await this.skillsPluginResolver.discoverSkillNames(
@@ -6596,6 +6606,7 @@ ${input.userComment}
 				sessionPlatform === "linear"
 					? this.config.linearMcpConfigs
 					: this.config.githubMcpConfigs,
+			strictMcpConfig: this.config.strictMcpConfig,
 			linearWorkspaceId,
 			cyrusHome: this.cyrusHome,
 			logger: log,
@@ -6937,6 +6948,7 @@ ${input.userComment}
 							...(allowedTools.length > 0 && { allowedTools }),
 							...(disallowedTools.length > 0 && { disallowedTools }),
 							settingSources: ["user", "project", "local"],
+							strictMcpConfig: this.config.strictMcpConfig ?? true,
 							// CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is intentionally not set here;
 							// see CYPACK-1108 and ClaudeRunner.start() for context.
 							env: buildBaseSessionEnv(),

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -96,6 +96,8 @@ export interface ChatRunnerConfigInput {
 	 * run as usual).
 	 */
 	platformMcpConfigOverrides?: readonly string[];
+	/** Whether Claude should ignore ambient MCP configuration. Defaults to true. */
+	strictMcpConfig?: boolean;
 	/** Plugins to load for the chat session (provides managed skills). */
 	plugins?: SdkPluginConfig[];
 	/**
@@ -141,6 +143,8 @@ export interface IssueRunnerConfigInput {
 	 * (see `buildIssueConfig`).
 	 */
 	platformMcpConfigOverrides?: readonly string[];
+	/** Whether Claude should ignore ambient MCP configuration. Defaults to true. */
+	strictMcpConfig?: boolean;
 	linearWorkspaceId?: string;
 	cyrusHome: string;
 	logger: ILogger;
@@ -297,6 +301,7 @@ export class RunnerConfigBuilder {
 			),
 			...(mcpConfig ? { mcpConfig } : {}),
 			...(mcpConfigPath ? { mcpConfigPath } : {}),
+			strictMcpConfig: input.strictMcpConfig ?? true,
 			...(input.resumeSessionId
 				? { resumeSessionId: input.resumeSessionId }
 				: {}),
@@ -438,6 +443,7 @@ export class RunnerConfigBuilder {
 			cyrusHome: input.cyrusHome,
 			mcpConfigPath,
 			mcpConfig,
+			strictMcpConfig: input.strictMcpConfig ?? true,
 			appendSystemPrompt: appendCloudRuntimeAddendum(
 				appendBrowserUseAddendum(appendFailureModeAddendum(input.systemPrompt)),
 			),

--- a/packages/edge-worker/test/ConfigManager.test.ts
+++ b/packages/edge-worker/test/ConfigManager.test.ts
@@ -64,4 +64,32 @@ describe("ConfigManager", () => {
 			opencode,
 		);
 	});
+
+	it("reloads strictMcpConfig=false and emits it as a global config change", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "cyrus-config-manager-"));
+		const configPath = join(tempDir, "config.json");
+		const initialConfig: EdgeWorkerConfig = {
+			repositories: [repo],
+			strictMcpConfig: true,
+		};
+		const manager = new ConfigManager(
+			initialConfig,
+			logger,
+			configPath,
+			new Map([[repo.id, repo]]),
+		);
+		const onConfigChanged = vi.fn();
+		manager.on("configChanged", onConfigChanged);
+
+		await writeFile(
+			configPath,
+			JSON.stringify({ repositories: [repo], strictMcpConfig: false }),
+		);
+		await (manager as any).handleConfigChange();
+
+		expect(onConfigChanged).toHaveBeenCalledOnce();
+		expect(onConfigChanged.mock.calls[0][0].newConfig.strictMcpConfig).toBe(
+			false,
+		);
+	});
 });

--- a/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.chat-config.test.ts
@@ -64,6 +64,29 @@ function makeIssueBuilder(
 }
 
 describe("RunnerConfigBuilder.buildChatConfig", () => {
+	it("defaults strict MCP configuration on and preserves an explicit opt-out", () => {
+		const builder = makeBuilder();
+		const baseInput = {
+			workspacePath: "/tmp/slack-workspace",
+			workspaceName: "slack-thread-x",
+			systemPrompt: "test",
+			sessionId: "sess-1",
+			cyrusHome: "/tmp/cyrus-home-test",
+			platformName: "slack",
+			logger: silentLogger,
+			onMessage: () => {},
+			onError: () => {},
+		};
+
+		expect(builder.buildChatConfig(baseInput).strictMcpConfig).toBe(true);
+		expect(
+			builder.buildChatConfig({
+				...baseInput,
+				strictMcpConfig: false,
+			}).strictMcpConfig,
+		).toBe(false);
+	});
+
 	it("includes autoMemoryDirectory in allowedDirectories so the session can read existing memory files (CYPACK-1197)", () => {
 		const builder = makeBuilder();
 		const cyrusHome = "/tmp/cyrus-home-test";


### PR DESCRIPTION
Assignee: @Connoropolous ([Connor Turland](https://linear.app/ceedar/profiles/connor))

## Summary

- add an enabled-by-default `strictMcpConfig` field to Cyrus config and its generated schemas
- pass the setting through chat, issue, hot-reload, and pre-warmed Claude session paths
- set the Claude Agent SDK `strictMcpConfig` option from config, allowing operators to opt into authenticated claude.ai connectors and other ambient MCP sources
- add regression coverage for schema parsing, reload behavior, runner config construction, and SDK options

Companion UI and persistence change: [cyrus-hosted#1043](https://github.com/cyrusagents/cyrus-hosted/pull/1043)

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:packages:run`
- `pnpm build` (pre-commit hook)

Linear: [CYHOST-1245](https://linear.app/ceedar/issue/CYHOST-1245/can-u-add-a-bevahiours-settings-page-setting-for-strict-mcp-config)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
