### PR TITLE
chore: release v0.2.69

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.69] - 2026-08-26
+
 ### Fixed
 - Removed obsolete synthetic `fallback_credit` usage fields so all runner packages build against the current shared SDK types. ([#1428](https://github.com/cyrusagents/cyrus/pull/1428))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.69] - 2026-08-26
+
 ### Added
 - Added an enabled-by-default `strictMcpConfig` setting for Claude sessions. Set it to `false` to make ambient MCP sources—including authenticated claude.ai connectors, project and user settings, and plugins—available alongside Cyrus-configured servers; config reloads and pre-warmed sessions honor changes. ([CYHOST-1245](https://linear.app/ceedar/issue/CYHOST-1245/can-u-add-a-bevahiours-settings-page-setting-for-strict-mcp-config), [#1434](https://github.com/cyrusagents/cyrus/pull/1434))
 - OpenCode is now a supported Cyrus runner for self-hosted sessions, including `opencode` labels and `[agent=opencode]` selectors, provider/model defaults, runtime config overrides, MCP and tool permission translation, CLI-managed auth/state handling, readable Linear activity, session resume/follow-up handling, and stalled-runner recovery. Thanks @JappyMondo and @jappyjan for the original contribution. ([CYPACK-1466](https://linear.app/ceedar/issue/CYPACK-1466/create-clean-opencode-support-pr-from-pr-1263-tip), [#1426](https://github.com/cyrusagents/cyrus/pull/1426))
@@ -18,6 +20,56 @@ All notable changes to this project will be documented in this file.
 ### Security
 - Patched newly reported Cyrus CLI dependency advisories so `pnpm audit` reports no known vulnerabilities. ([CYPACK-1431](https://linear.app/ceedar/issue/CYPACK-1431/address-open-security-patches-for-cyrus-cli), [#1404](https://github.com/cyrusagents/cyrus/pull/1404))
 - Removed an unused Gemini runner reference dependency so `pnpm audit` no longer reports the `extract-zip` advisory. ([CYPACK-1443](https://linear.app/ceedar/issue/CYPACK-1443/address-open-security-patches-for-cyrus-cli), [#1409](https://github.com/cyrusagents/cyrus/pull/1409))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.69
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.69
+
+#### cyrus-core
+- cyrus-core@0.2.69
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.69
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.69
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.69
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.69
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.69
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.69
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.69
+
+#### cyrus-opencode-runner
+- cyrus-opencode-runner@0.2.69
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.69
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.69
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.69
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.69
+
+#### cyrus-ai (CLI)
+- cyrus-ai@0.2.69
 
 ## [0.2.68] - 2026-08-05
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-08-26-cypack-1474-release-v0.2.69.md
+++ b/apps/f1/test-drives/2026-08-26-cypack-1474-release-v0.2.69.md
@@ -1,0 +1,66 @@
+# Test Drive: CYPACK-1474 Release v0.2.69
+
+**Date**: 2026-08-26
+**Goal**: Validate the local F1 issue, Claude session, and activity-rendering flow before publishing v0.2.69.
+**Test Repo**: `/tmp/f1-release-v0.2.69-6y1Y1T/repo`
+**F1 Port**: `3600`
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Session started
+- [x] Worktree created
+- [x] Activities tracked
+- [x] Claude processed the issue successfully
+
+### Renderer
+- [x] Activity format correct
+- [x] Pagination works
+- [ ] Search works (the F1 CLI has no session-search command)
+
+## Session Log
+
+```bash
+apps/f1/f1 init-test-repo --path /tmp/f1-release-v0.2.69-6y1Y1T/repo
+CYRUS_PORT=3600 CYRUS_DEFAULT_RUNNER=claude \
+  CYRUS_REPO_PATH=/tmp/f1-release-v0.2.69-6y1Y1T/repo \
+  bun run apps/f1/server.ts
+CYRUS_PORT=3600 apps/f1/f1 ping
+CYRUS_PORT=3600 apps/f1/f1 status
+```
+
+Result: the fresh test repository was initialized, the server started on port 3600, ping returned healthy, and status returned `ready`.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 create-issue \
+  --title "Release v0.2.69 F1 validation" \
+  --description "Validate the Cyrus v0.2.69 release by inspecting the configured repository and reporting its current implementation status. Do not edit files."
+CYRUS_PORT=3600 apps/f1/f1 start-session --issue-id issue-1
+CYRUS_PORT=3600 apps/f1/f1 prompt-session \
+  --session-id session-1 \
+  --message "Use the configured test repository for this issue."
+```
+
+Result: F1 created `issue-1` / `DEF-1` and `session-1`. After repository selection, EdgeWorker created the issue worktree, selected the Claude runner, and reported model `claude/claude-sonnet-5`.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 10 --offset 0
+```
+
+Result: the Claude-backed inspection completed successfully. The session rendered 18 coherent activities, including elicitation, prompt, thought, action, and final response activity. Pagination returned the requested 10-row window and displayed continuation guidance.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 stop-session --session-id session-1
+```
+
+Result: the session stop request succeeded and the F1 server shut down gracefully.
+
+## Final Retrospective
+
+F1 validated the full local server, issue tracker, repository-selection recovery, worktree creation, Claude execution, activity rendering, pagination, successful final response, session stop, and graceful server shutdown paths for v0.2.69. The generated test repository intentionally has unfinished algorithms and tests; the agent correctly performed an inspection-only task without modifying it.

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"repository": {
 		"type": "git",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Configuration update handlers for Cyrus agent",
 	"repository": {
 		"type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Core business logic for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"repository": {
 		"type": "git",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/opencode-runner/package.json
+++ b/packages/opencode-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-opencode-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "OpenCode CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Simple agent runner for enumerated responses",
 	"repository": {
 		"type": "git",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.68",
+	"version": "0.2.69",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
- Prepare all Cyrus packages and the CLI for v0.2.69
- Move public and internal Unreleased changelog entries into the release
- Add F1 release smoke evidence

## Verification
- `node scripts/release-packages.mjs validate 0.2.69`
- `pnpm audit --audit-level low`
- `pnpm test:packages:run`
- `pnpm --filter cyrus-ai test:run`
- `pnpm typecheck`
- `pnpm build`
- F1 release test drive passed

Closes CYPACK-1474