### PR TITLE
fix(release): preflight unpublished npm packages

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -91,6 +91,21 @@ jobs:
             fi
           fi
 
+          missing_packages=()
+          while IFS=$'\t' read -r directory package_name; do
+            if ! npm view "$package_name" version >/dev/null 2>&1; then
+              missing_packages+=("$package_name")
+            fi
+          done < <(node scripts/release-packages.mjs list)
+
+          if (( ${#missing_packages[@]} > 0 )); then
+            echo "::error title=Unpublished npm package(s)::Every release package must already exist on npm before this workflow runs."
+            printf '  - %s\n' "${missing_packages[@]}"
+            echo "Bootstrap each missing package through the approved npm first-publish process, then configure its GitHub Actions trusted publisher."
+            echo "Trusted publisher command: npm trust github <package> --repo cyrusagents/cyrus --file release-cli.yml --allow-publish --yes"
+            exit 1
+          fi
+
           while IFS=$'\t' read -r directory package_name; do
             if npm view "${package_name}@${REQUESTED_VERSION}" version >/dev/null 2>&1; then
               if [[ "$DRY_RUN" == "true" ]]; then

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Fixed
-- Release workflows now preflight npm package existence before running release work, with actionable first-publish and trusted-publisher guidance for newly added packages.
+- Release workflows now preflight npm package existence before running release work, with actionable first-publish and trusted-publisher guidance for newly added packages ([#1436](https://github.com/cyrusagents/cyrus/pull/1436)).
 
 ## [0.2.69] - 2026-08-26
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Fixed
+- Release workflows now preflight npm package existence before running release work, with actionable first-publish and trusted-publisher guidance for newly added packages.
+
 ## [0.2.69] - 2026-08-26
 
 ### Fixed

--- a/apps/cli/RELEASING.md
+++ b/apps/cli/RELEASING.md
@@ -60,6 +60,27 @@ The validator rejects version drift, missing packages, incorrect dependency
 order, stale repository metadata, incomplete changelogs, and missing F1 release
 evidence.
 
+Before a release workflow can publish, every package listed by
+`node scripts/release-packages.mjs list` must already exist on npm. npm trusted
+publishing cannot create a package on its first publish, so adding a new public
+workspace requires a one-time bootstrap through the approved npm first-publish
+process. After that initial version exists, configure the package's GitHub
+Actions trusted publisher with the exact `cyrusagents/cyrus` repository and
+`release-cli.yml` workflow:
+
+```sh
+npm trust github <package-name> \
+  --repo cyrusagents/cyrus \
+  --file release-cli.yml \
+  --allow-publish \
+  --yes
+```
+
+The release workflow preflights package existence before installing
+dependencies or publishing anything. If a package is missing, it stops with
+the bootstrap and trusted-publisher instructions instead of partially
+publishing the dependency graph.
+
 ## Dispatch a release
 
 From GitHub, open **Actions → Release Cyrus CLI → Run workflow**, select

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -164,6 +164,25 @@ describe("trusted Cyrus release workflow", () => {
 		);
 	});
 
+	it("preflights package existence before any release work or publishing", () => {
+		expect(workflow).toContain("missing_packages=()");
+		expect(workflow).toContain(
+			'npm view "$package_name" version >/dev/null 2>&1',
+		);
+		expect(workflow).toContain(
+			"Every release package must already exist on npm before this workflow runs.",
+		);
+		expect(workflow).toContain(
+			"npm trust github <package> --repo cyrusagents/cyrus --file release-cli.yml --allow-publish --yes",
+		);
+		expect(workflow.indexOf("missing_packages=()")).toBeLessThan(
+			workflow.indexOf("Install locked dependencies"),
+		);
+		expect(workflow.indexOf("missing_packages=()")).toBeLessThan(
+			workflow.indexOf('npm publish "$tarball"'),
+		);
+	});
+
 	it("finishes a live release with a tag and GitHub release", () => {
 		expect(workflow).toMatch(/git tag --annotate "v\$\{REQUESTED_VERSION\}"/);
 		expect(workflow).toMatch(/git push origin "v\$\{REQUESTED_VERSION\}"/);


### PR DESCRIPTION
## Summary\n\n- Preflight every package in the release manifest with npm before dependency installation or publishing.\n- Fail with actionable first-publish and trusted-publisher instructions when a package is not yet published.\n- Document the one-time bootstrap process and cover the guard with release workflow tests.\n\nThis prevents a newly added npm package from causing a partial release after earlier packages have already been published.\n\n## Validation\n\n- pnpm --filter cyrus-ai exec vitest run release-workflow.test.ts\n- pnpm lint (passes with existing warnings)\n- pnpm typecheck\n- pnpm build