### PR TITLE
chore: prepare v0.2.70 release

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.70] - 2026-08-27
+
 ### Added
 - Guardrails against silently dropped `EdgeConfig` fields (the CYPACK-1478 / CYHOST-967 bug class): `WorkerService.startEdgeWorker` now spreads the entire file config so pass-through fields forward automatically, `ConfigManager`'s hot-reload merge and global-change watch are driven by a single `RELOAD_MERGED_KEYS` list with a compile-time exhaustiveness check that names any unclassified schema key, and a schema-complete CLI test asserts every `EdgeConfig` field survives into the `EdgeWorkerConfig`. ([CYPACK-1478](https://linear.app/ceedar/issue/CYPACK-1478/if-a-mcp-server-has-no-enabled-tools-will-it-not-be-allowed-as-an-mcp), [#1440](https://github.com/cyrusagents/cyrus/pull/1440))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,64 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.70] - 2026-08-27
+
 ### Fixed
 - `strictMcpConfig: false` in `~/.cyrus/config.json` now actually takes effect at startup. Previously the CLI dropped the setting when assembling the worker configuration, so sessions were still launched in strict MCP mode and ambient MCP sources (claude.ai connectors, settings-file servers, plugins) never loaded despite the opt-out. ([CYPACK-1478](https://linear.app/ceedar/issue/CYPACK-1478/if-a-mcp-server-has-no-enabled-tools-will-it-not-be-allowed-as-an-mcp), [#1440](https://github.com/cyrusagents/cyrus/pull/1440))
 - An audit prompted by the same bug found and fixed other silently dropped settings: `cursorDefaultModel` / `cursorDefaultFallbackModel` were ignored at startup, and edits to `userAccessControl`, `global_setup_script`, and Cursor model defaults in `~/.cyrus/config.json` were not picked up by live config reloads. ([CYPACK-1478](https://linear.app/ceedar/issue/CYPACK-1478/if-a-mcp-server-has-no-enabled-tools-will-it-not-be-allowed-as-an-mcp), [#1440](https://github.com/cyrusagents/cyrus/pull/1440))
 
 ### Changed
 - Updated `@anthropic-ai/claude-agent-sdk` from `0.3.245` to [`0.3.247`](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#03247), adding per-turn message correlation, managed model pricing, per-task stop control, ambient task metadata, and live permission-mode reporting fixes. Updated `@anthropic-ai/sdk` from `^0.120.0` to [`^0.121.0`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#01210-2026-08-26); the Claude tool allowance lists are unchanged. ([CYPACK-1476](https://linear.app/ceedar/issue/CYPACK-1476/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest), [#1438](https://github.com/cyrusagents/cyrus/pull/1438))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.70
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.70
+
+#### cyrus-core
+- cyrus-core@0.2.70
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.70
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.70
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.70
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.70
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.70
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.70
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.70
+
+#### cyrus-opencode-runner
+- cyrus-opencode-runner@0.2.70
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.70
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.70
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.70
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.70
+
+#### cyrus-ai
+- cyrus-ai@0.2.70
 
 ## [0.2.69] - 2026-08-26
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-08-27-cypack-1478-release-v0.2.70.md
+++ b/apps/f1/test-drives/2026-08-27-cypack-1478-release-v0.2.70.md
@@ -1,0 +1,78 @@
+# Test Drive: CYPACK-1478 Release v0.2.70
+
+**Date**: 2026-08-27
+**Goal**: Validate the local F1 issue, Claude session, and activity-rendering flow before publishing v0.2.70.
+**Test Repo**: `/tmp/f1-release-v0.2.70-23d794e4/repo`
+**F1 Port**: `3600`
+**Reference Issue**: CYPACK-1478 (fix(cli): thread strictMcpConfig from config file into EdgeWorker startup config, #1440) — the strictMcpConfig fix and its accompanying schema-completeness guardrails are the primary CLI/EdgeWorker changes carried by this release.
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Session started
+- [x] Worktree created
+- [x] Activities tracked
+- [x] Claude processed the issue successfully
+
+### Renderer
+- [x] Activity format correct
+- [x] Pagination works
+- [ ] Search works (the F1 CLI has no session-search command)
+
+## Session Log
+
+```bash
+apps/f1/f1 init-test-repo --path /tmp/f1-release-v0.2.70-23d794e4/repo
+CYRUS_PORT=3600 CYRUS_DEFAULT_RUNNER=claude \
+  CYRUS_REPO_PATH=/tmp/f1-release-v0.2.70-23d794e4/repo \
+  bun run apps/f1/server.ts
+CYRUS_PORT=3600 apps/f1/f1 ping
+CYRUS_PORT=3600 apps/f1/f1 status
+```
+
+Result: port 3600 was confirmed free before starting; the fresh test repository was initialized (token-bucket implemented, sliding/fixed window + Redis adapter + tests left as TODOs, matching the standard F1 scaffold); the server started cleanly on port 3600 with no startup errors or warnings in the boot log. `status` returned `ready`. `ping` returned success but printed `Status: undefined` — this is a pre-existing F1 CLI/RPC field-name mismatch (`CLIRPCServer.handlePing` returns `{message: "pong", timestamp}` while `apps/f1/src/commands/ping.ts` reads `result.status`), unrelated to the CYPACK-1478 changes; not a regression and not release-blocking.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 create-issue \
+  --title "Release v0.2.70 F1 validation" \
+  --description "Validate the Cyrus v0.2.70 release by inspecting the configured repository and reporting its current implementation status. Do not edit files."
+CYRUS_PORT=3600 apps/f1/f1 start-session --issue-id issue-1
+CYRUS_PORT=3600 apps/f1/f1 prompt-session \
+  --session-id session-1 \
+  --message "Use the configured test repository for this issue."
+```
+
+Result: F1 created `issue-1` / `DEF-1` and `session-1`. The session immediately elicited a repository selection ("Which repository should I work in for this issue?"); after `prompt-session` responded with the configured-repo instruction, EdgeWorker created the `DEF-1` git worktree, resolved routing to the "F1 Test Repository", assigned a Claude SDK session ID (`59b17dcb-2677-4b50-9f9d-d3f00ca6b41d`), and reported model `claude/claude-sonnet-5`.
+
+One benign SDK-level warning was observed in the server log during runner startup: `canUseTool will not be invoked for: Bash, Task, WebFetch, ... (code: CLAUDE_SDK_CAN_USE_TOOL_SHADOWED)`. This is an informational warning from the bundled `@anthropic-ai/claude-agent-sdk` about bare `allowedTools` entries bypassing the `canUseTool` callback; it did not block or degrade the session (all 16 timeline activities and the final response rendered correctly afterward), and is unrelated to the strictMcpConfig fix under test.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 10 --offset 0
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 10 --offset 10
+```
+
+Result: the Claude-backed inspection completed successfully (`Session completed (subtype: success)`, 42 raw SDK messages). The session rendered 16 coherent timeline activities: `elicitation` → `prompt` → 3x `thought` (acknowledgement, routing decision, model selection) → 10x `action` (Bash/Read tool calls exploring the repo) → final `response`. The final response was a well-structured Markdown status report covering implemented features (token bucket algorithm, in-memory storage adapter, public API/types), explicitly TODO'd features (sliding window, fixed window, Redis adapter, tests), a build-tooling caveat (no `node_modules` installed, so `tsc --noEmit` could not be run), and confirmation that no files were modified — correctly honoring the inspection-only instruction. Pagination with `--limit 10 --offset 0` returned the first 10 activities plus a "Showing 10 of 16 activities / Use --limit and --offset to view more" footer; `--offset 10` returned the remaining 6 activities including the final response, confirming correct windowing.
+
+Post-session filesystem check confirmed `git status --short` was empty in the `DEF-1` worktree (still at the single scaffold commit `b6f816c`) — the agent made no edits, consistent with the inspection-only task.
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 stop-session --session-id session-1
+```
+
+Result: the session stop request succeeded (`Session stopped successfully`, EdgeWorker logged "Stopped session session-1 (interrupt not supported)" since the session had already completed). The server was then sent `SIGTERM` and shut down gracefully, logging `✅ Saved EdgeWorker state for 1 sessions` and `✅ Server stopped gracefully`.
+
+## Final Retrospective
+
+F1 validated the full local server, issue tracker, repository-selection recovery, worktree creation, Claude execution, activity rendering, pagination, successful final response, session stop, and graceful server shutdown paths for v0.2.70. All core pass/fail criteria from the F1 skill were met: server started without error, issue and session creation succeeded, activities appeared and rendered coherently, the final response was well-formed, the session stopped cleanly, and no unhandled exceptions occurred.
+
+Two non-blocking, pre-existing observations were noted (neither is a regression introduced by the CYPACK-1478 changes being released):
+1. `f1 ping` prints `Status: undefined` due to a field-name mismatch between the RPC handler (`message`) and the CLI (`status`) — cosmetic only, health check still reports success.
+2. A benign `CLAUDE_SDK_CAN_USE_TOOL_SHADOWED` warning is logged by the bundled Claude Agent SDK about bare `allowedTools` entries; it does not affect session behavior or output.
+
+As with the v0.2.69 drive, the generated test repository intentionally has unfinished algorithms and tests, and the agent correctly performed an inspection-only task without modifying it. No regressions were observed in the areas touched by CYPACK-1478 (config-file → EdgeWorker startup config field propagation) — the session started, routed, and executed normally end-to-end. **v0.2.70 is validated for publishing.**

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"repository": {
 		"type": "git",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Configuration update handlers for Cyrus agent",
 	"repository": {
 		"type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Core business logic for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"repository": {
 		"type": "git",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/opencode-runner/package.json
+++ b/packages/opencode-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-opencode-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "OpenCode CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Simple agent runner for enumerated responses",
 	"repository": {
 		"type": "git",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.69",
+	"version": "0.2.70",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

Coordinated release prep for **v0.2.70** across all 16 published workspaces.

- Rolled both changelogs' `Unreleased` sections into `[0.2.70] - 2026-08-27`
- Bumped every manifest listed by `node scripts/release-packages.mjs list` to `0.2.70`
- `pnpm install` produced no lockfile change
- Added the full `package@0.2.70` list to the release section in `CHANGELOG.md`
- F1 release test-drive evidence: `apps/f1/test-drives/2026-08-27-cypack-1478-release-v0.2.70.md`

### Release contents
- Fix: `strictMcpConfig: false` honored at startup + audit fixes for other silently dropped config fields (CYPACK-1478, #1440)
- Changed: `@anthropic-ai/claude-agent-sdk` 0.3.247 / `@anthropic-ai/sdk` ^0.121.0 (CYPACK-1476, #1438)
- Internal: EdgeConfig field-drop guardrails (#1440), release preflight for unpublished packages (#1436)

### Checks
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test:packages:run`
- [x] `pnpm lint` (warnings only, pre-existing)
- [x] F1 release test drive report (`2026-08-27-cypack-1478-release-v0.2.70.md`) — all core checks passed
- [x] `node scripts/release-packages.mjs validate 0.2.70` — "Validated 16 release packages at 0.2.70."

After merge: dispatch `release-cli.yml` from `main` in dry-run, then live with `dist_tag=latest`.

<!-- generated-by-cyrus -->