### PR TITLE
fix(release): extend npm visibility wait from 60s to 10 minutes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -210,20 +210,26 @@ jobs:
             local package_name="$1"
             local published=""
             local tagged=""
+            # npm warns that a fresh publish "may take a few minutes to become
+            # available", so allow up to 10 minutes before declaring failure.
+            local deadline=$((SECONDS + 600))
+            local attempt=0
 
-            for attempt in {1..12}; do
+            while true; do
+              attempt=$((attempt + 1))
               published="$(npm view "${package_name}@${REQUESTED_VERSION}" version 2>/dev/null || true)"
               tagged="$(npm view "$package_name" "dist-tags.${DIST_TAG}" 2>/dev/null || true)"
               if [[ "$published" == "$REQUESTED_VERSION" && "$tagged" == "$REQUESTED_VERSION" ]]; then
                 return 0
               fi
-              if [[ "$attempt" -lt 12 ]]; then
-                echo "Waiting for ${package_name}@${REQUESTED_VERSION} with npm tag ${DIST_TAG} to become visible (attempt ${attempt}/12)."
-                sleep 5
+              if [[ "$SECONDS" -ge "$deadline" ]]; then
+                break
               fi
+              echo "Waiting for ${package_name}@${REQUESTED_VERSION} with npm tag ${DIST_TAG} to become visible (attempt ${attempt}, retrying for up to 10 minutes)."
+              sleep 10
             done
 
-            echo "${package_name}@${REQUESTED_VERSION} is not consistently visible with npm tag ${DIST_TAG}." >&2
+            echo "${package_name}@${REQUESTED_VERSION} is not consistently visible with npm tag ${DIST_TAG} after 10 minutes." >&2
             return 1
           }
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -5,7 +5,7 @@ This changelog documents internal development changes, refactors, tooling update
 ## [Unreleased]
 
 ### Fixed
-- The release workflow's npm registry visibility check now waits up to 10 minutes per package instead of 60 seconds. The v0.2.70 release run aborted mid-graph because npm's publish processing exceeded the old 12×5s window even though the publish itself succeeded; the new deadline matches npm's own "may take a few minutes" guidance.
+- The release workflow's npm registry visibility check now waits up to 10 minutes per package instead of 60 seconds. The v0.2.70 release run aborted mid-graph because npm's publish processing exceeded the old 12×5s window even though the publish itself succeeded; the new deadline matches npm's own "may take a few minutes" guidance. ([CYPACK-1478](https://linear.app/ceedar/issue/CYPACK-1478/if-a-mcp-server-has-no-enabled-tools-will-it-not-be-allowed-as-an-mcp), [#1442](https://github.com/cyrusagents/cyrus/pull/1442))
 
 ## [0.2.70] - 2026-08-27
 

--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,9 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+### Fixed
+- The release workflow's npm registry visibility check now waits up to 10 minutes per package instead of 60 seconds. The v0.2.70 release run aborted mid-graph because npm's publish processing exceeded the old 12×5s window even though the publish itself succeeded; the new deadline matches npm's own "may take a few minutes" guidance.
+
 ## [0.2.70] - 2026-08-27
 
 ### Added

--- a/apps/cli/release-workflow.test.ts
+++ b/apps/cli/release-workflow.test.ts
@@ -147,7 +147,9 @@ describe("trusted Cyrus release workflow", () => {
 	it("recovers safely from partially published npm releases", () => {
 		expect(workflow).toContain("verify_registry_version() {");
 		expect(workflow).toContain("tarball_integrity() {");
-		expect(workflow).toContain("for attempt in {1..12}; do");
+		expect(workflow).toContain("local deadline=$((SECONDS + 600))");
+		expect(workflow).toContain('if [[ "$SECONDS" -ge "$deadline" ]]');
+		expect(workflow).toContain("sleep 10");
 		expect(workflow).toContain("dist.integrity");
 		expect(workflow).toContain('createHash("sha512")');
 		expect(workflow).toContain(
@@ -160,7 +162,7 @@ describe("trusted Cyrus release workflow", () => {
 			`Dry run would publish \${package_name}@\${REQUESTED_VERSION} with npm tag \${DIST_TAG}.`,
 		);
 		expect(workflow).toContain(
-			`\${package_name}@\${REQUESTED_VERSION} is not consistently visible with npm tag \${DIST_TAG}.`,
+			`\${package_name}@\${REQUESTED_VERSION} is not consistently visible with npm tag \${DIST_TAG} after 10 minutes.`,
 		);
 	});
 


### PR DESCRIPTION
## Summary

Prevents a recurrence of the v0.2.70 live-release failure (run 33126114454): the workflow published `cyrus-core@0.2.70` successfully, but npm's publish processing exceeded the visibility check's hard 60-second budget (12 attempts × 5s), so the run aborted after 3 of 16 packages.

npm's own publish output warns that a package may take a few minutes to become available. This change makes `verify_registry_version` poll every 10 seconds against a 10-minute deadline, so routine registry lag can no longer kill a release mid-graph. The failure remains loud when a package genuinely never becomes visible.

- `.github/workflows/release-cli.yml` — deadline-based retry loop in `verify_registry_version`
- `apps/cli/release-workflow.test.ts` — guards the 600-second deadline, timeout condition, polling interval, and failure message
- `CHANGELOG.internal.md` — linked entry under Unreleased

## Test plan

- `pnpm -r test:run`
- `pnpm test:packages:run`
- `pnpm --filter cyrus-ai test:run`
- `pnpm typecheck`
- `pnpm lint` (passes with 11 pre-existing warnings)
- `pnpm build` (pre-commit hook)

Linear: [CYPACK-1478](https://linear.app/ceedar/issue/CYPACK-1478/if-a-mcp-server-has-no-enabled-tools-will-it-not-be-allowed-as-an-mcp)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
