### PR TITLE
Update Anthropic SDKs to latest (CYPACK-1481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Updated `@anthropic-ai/claude-agent-sdk` from `0.3.247` to [`0.3.250`](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md#03250), adding per-server SDK-hosted MCP timeouts and parity with Claude Code 2.1.250. Updated `@anthropic-ai/sdk` from `^0.121.0` to [`^0.122.0`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/CHANGELOG.md#01220-2026-08-27), and refreshed the Claude tool allowances to add agent/resource discovery tools and remove the retired onboarding-guide tool. ([CYPACK-1481](https://linear.app/ceedar/issue/CYPACK-1481/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest), [#1443](https://github.com/cyrusagents/cyrus/pull/1443))
+
 ## [0.2.70] - 2026-08-27
 
 ### Fixed

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -21,8 +21,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.247",
-		"@anthropic-ai/sdk": "^0.121.0",
+		"@anthropic-ai/claude-agent-sdk": "0.3.250",
+		"@anthropic-ai/sdk": "^0.122.0",
 		"@linear/sdk": "^64.0.0",
 		"cyrus-core": "workspace:*",
 		"dotenv": "^16.4.5",

--- a/packages/claude-runner/src/config.ts
+++ b/packages/claude-runner/src/config.ts
@@ -23,6 +23,7 @@ export const availableTools = [
 	// Execution tools
 	"Bash",
 	"Task",
+	"ListAgents",
 
 	// Web tools
 	"WebFetch",
@@ -44,7 +45,6 @@ export const availableTools = [
 	// User interaction tools
 	"SendMessage",
 	"PushNotification",
-	"ShareOnboardingGuide",
 
 	// Plan and worktree management
 	"EnterWorktree",
@@ -63,8 +63,11 @@ export const availableTools = [
 	"TaskOutput",
 	"TaskStop",
 
-	// Tool discovery
+	// Tool and MCP resource discovery
 	"ToolSearch",
+	"ListMcpResourcesTool",
+	"ReadMcpResourceDirTool",
+	"ReadMcpResourceTool",
 
 	// Design sync
 	"DesignSync",
@@ -92,12 +95,15 @@ export const readOnlyTools: ToolName[] = [
 	"TaskGet",
 	"TaskList",
 	"Task",
+	"ListAgents",
 	"Skill",
 	"Monitor",
 	"LSP",
-	"ShareOnboardingGuide",
 	"TaskOutput",
 	"ToolSearch",
+	"ListMcpResourcesTool",
+	"ReadMcpResourceDirTool",
+	"ReadMcpResourceTool",
 ];
 
 /**

--- a/packages/claude-runner/test/config.test.ts
+++ b/packages/claude-runner/test/config.test.ts
@@ -19,6 +19,7 @@ describe("config", () => {
 				"Write(**)",
 				"Bash",
 				"Task",
+				"ListAgents",
 				"WebFetch",
 				"WebSearch",
 				"TaskCreate",
@@ -29,7 +30,6 @@ describe("config", () => {
 				"Skill",
 				"SendMessage",
 				"PushNotification",
-				"ShareOnboardingGuide",
 				"EnterWorktree",
 				"ExitWorktree",
 				"CronCreate",
@@ -42,11 +42,14 @@ describe("config", () => {
 				"TaskOutput",
 				"TaskStop",
 				"ToolSearch",
+				"ListMcpResourcesTool",
+				"ReadMcpResourceDirTool",
+				"ReadMcpResourceTool",
 				"DesignSync",
 				"Workflow",
 				"ReportFindings",
 			]);
-			expect(availableTools).toHaveLength(31);
+			expect(availableTools).toHaveLength(34);
 		});
 
 		it("should define read-only tools", () => {
@@ -59,14 +62,17 @@ describe("config", () => {
 				"TaskGet",
 				"TaskList",
 				"Task",
+				"ListAgents",
 				"Skill",
 				"Monitor",
 				"LSP",
-				"ShareOnboardingGuide",
 				"TaskOutput",
 				"ToolSearch",
+				"ListMcpResourcesTool",
+				"ReadMcpResourceDirTool",
+				"ReadMcpResourceTool",
 			]);
-			expect(readOnlyTools).toHaveLength(14);
+			expect(readOnlyTools).toHaveLength(17);
 		});
 
 		it("should define write tools", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.247",
+		"@anthropic-ai/claude-agent-sdk": "0.3.250",
 		"@linear/sdk": "^64.0.0",
 		"zod": "^4.3.6"
 	},

--- a/packages/core/src/allowed-tools-defaults.ts
+++ b/packages/core/src/allowed-tools-defaults.ts
@@ -38,6 +38,7 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	// Execution
 	"Bash",
 	"Task",
+	"ListAgents",
 
 	// Web
 	"WebFetch",
@@ -50,7 +51,6 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	// User interaction
 	"SendMessage",
 	"PushNotification",
-	"ShareOnboardingGuide",
 
 	// Task lifecycle
 	"TaskCreate",
@@ -71,6 +71,9 @@ export const LINEAR_DEFAULT_ALLOWED_TOOLS = [
 	"LSP",
 	"RemoteTrigger",
 	"ToolSearch",
+	"ListMcpResourcesTool",
+	"ReadMcpResourceDirTool",
+	"ReadMcpResourceTool",
 	"Skill",
 
 	// Design sync
@@ -158,6 +161,7 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	// Execution
 	"Bash",
 	"Task",
+	"ListAgents",
 
 	// Web
 	"WebFetch",
@@ -170,7 +174,6 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	// User interaction
 	"SendMessage",
 	"PushNotification",
-	"ShareOnboardingGuide",
 
 	// Task lifecycle
 	"TaskCreate",
@@ -191,6 +194,9 @@ export const GITHUB_DEFAULT_ALLOWED_TOOLS = [
 	"LSP",
 	"RemoteTrigger",
 	"ToolSearch",
+	"ListMcpResourcesTool",
+	"ReadMcpResourceDirTool",
+	"ReadMcpResourceTool",
 	"Skill",
 
 	// Design sync

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -28,7 +28,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.247",
+		"@anthropic-ai/claude-agent-sdk": "0.3.250",
 		"@linear/sdk": "^64.0.0",
 		"@ngrok/ngrok": "^1.5.1",
 		"chokidar": "^4.0.3",

--- a/packages/opencode-runner/src/config.ts
+++ b/packages/opencode-runner/src/config.ts
@@ -70,7 +70,10 @@ const CLAUDE_ONLY_TOOL_NAMES = new Set([
 	"designsync",
 	"workflow",
 	"reportfindings",
-	"shareonboardingguide",
+	"listagents",
+	"listmcpresourcestool",
+	"readmcpresourcedirtool",
+	"readmcpresourcetool",
 	"lsp",
 ]);
 

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -21,7 +21,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@anthropic-ai/claude-agent-sdk": "0.3.247",
+		"@anthropic-ai/claude-agent-sdk": "0.3.250",
 		"cyrus-claude-runner": "workspace:*",
 		"cyrus-core": "workspace:*"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,11 +147,11 @@ importers:
   packages/claude-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.247
-        version: 0.3.247(@anthropic-ai/sdk@0.121.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.250
+        version: 0.3.250(@anthropic-ai/sdk@0.122.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@anthropic-ai/sdk':
-        specifier: ^0.121.0
-        version: 0.121.0(zod@4.3.6)
+        specifier: ^0.122.0
+        version: 0.122.0(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -253,8 +253,8 @@ importers:
   packages/core:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.247
-        version: 0.3.247(@anthropic-ai/sdk@0.121.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.250
+        version: 0.3.250(@anthropic-ai/sdk@0.122.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -303,8 +303,8 @@ importers:
   packages/edge-worker:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.247
-        version: 0.3.247(@anthropic-ai/sdk@0.121.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.250
+        version: 0.3.250(@anthropic-ai/sdk@0.122.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       '@linear/sdk':
         specifier: ^64.0.0
         version: 64.0.0(encoding@0.1.13)
@@ -547,8 +547,8 @@ importers:
   packages/simple-agent-runner:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.247
-        version: 0.3.247(@anthropic-ai/sdk@0.121.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.250
+        version: 0.3.250(@anthropic-ai/sdk@0.122.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)
       cyrus-claude-runner:
         specifier: workspace:*
         version: link:../claude-runner
@@ -587,60 +587,60 @@ importers:
 
 packages:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.247':
-    resolution: {integrity: sha512-vvCMAXy2KmiGHbJuThv+W6a+49qjofMR6S71FM8FTbkAAKg62cYcEyzVMVM3pNpBM5PtkMe8lRCqKnT9NUo6ng==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.250':
+    resolution: {integrity: sha512-tcekW4gR2UH0Q3COBaNPQIdud2lKEbs0HfG2yNKC18hXFPpgbuLCdjq0ndS1lcvC1q8ncPW3oQPUutQt3StICQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.247':
-    resolution: {integrity: sha512-742ZXrdAxHvw+vzMFJMMvfbH8mWWCBajQH27BT+3fQU3Frjqu9gXKvA63dvQgxwjqO1gYU9TSy/A6PKq7zujaQ==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.250':
+    resolution: {integrity: sha512-8Yxmmi76oVEIam+oRgxcL2RtqEkKX9Gp4rh500HmMltjX3Tk/ryjCoJEHoaUdU/LU6vWvfQU5W+dB/SJCQQb2A==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.247':
-    resolution: {integrity: sha512-8UNRQcSy9lpLhknXryid5cTfxHxBZft4oK5R0XIIZUXY/tXvsNP3+kVYAHQUNyc1J8IDa15sd19iKkMJMqFodA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.250':
+    resolution: {integrity: sha512-wpe2UmFrC2wyR+DbG6zIiRmqiFvK8nJjdi++nf3jNn0ZSHvW2BqPrh+JnPJOcmkAYR58IdMIj2jagbQAGtN/rA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.247':
-    resolution: {integrity: sha512-5/3ZQ9vOwrLv6w0CFjdbaTxPFyabHNLAEojkeiYmKzqlZ/taXG58/kVKgjqgx2qQhjcHCzy9JXDw5kp3RKJoGw==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.250':
+    resolution: {integrity: sha512-exABrKfqDv9rp6UCqOTjd4rH1lH6YZt0IuGFsAEHg52N08i5+4/uRtUlQzMf0VpN/dgqDoxt5jpOB9hH863r9w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.247':
-    resolution: {integrity: sha512-iMLjkVHbcxQ5WY2WwieOJK57kD4c8Cc2tpHwpEmdTDsnWLfmNt3XFuJdmeROwyra+tcVA52oHL0dWr51+V50Pg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.250':
+    resolution: {integrity: sha512-ZMjXn2r00SlS17ozg6RfK+OF7kPo3COrCUTPrKnXZk7AYZ+hE0xqunrkt66LwYNFc+KlvDTAZZHSiZVblTT7rA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.247':
-    resolution: {integrity: sha512-+tEIHgblLvBF+datSZb9WwnODXsFI7JxSFvm++oliH0eQO5zGDq0LD0hbY6h/A3nqODnBbIwVVBykwXMn68GPg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.250':
+    resolution: {integrity: sha512-skqoeRDEjobqtIXmt9GNWJUyjcSvKHEf5QVf4PF9v37CtkJWEt7Hs64yFkahFD1mY34FAUyy/Ij0NrbeGKHPBg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.247':
-    resolution: {integrity: sha512-Sni6U2xR55bUEJRv7Eikm6oC27IOn3rlVJZAzXRFCAgkf9+aBqq/dEUJiIcRT2xbXOIe5QdPGUmpnYfU1BsHMw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.250':
+    resolution: {integrity: sha512-PC3pzcV8/bT9+PAM9k4fGMU64YY0F9NV6f/G4vbLMqz4qZAWqQp9AXMea+F5KULeJG2ygaAhmhcDyOzW77HhEw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.247':
-    resolution: {integrity: sha512-yWfZo2ER3EIS/3pv6EX1M/VrZXu+zFzKhgWJjGgFSlcupbaCAxrVBRTdCyfv5UYBKWH9kl5HjgV2HhLHq67LSw==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.250':
+    resolution: {integrity: sha512-PjJRbJwDHccSUWls5gTiuXMgERit1WrrMQzzRqhhBHGzrlQueHVodrpg7HaN5gtirADJzfINcc7azq8j3qcEYw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.247':
-    resolution: {integrity: sha512-T9BDPloZxABkGREDRbWA7TVa9SLBMWI5GQXw39+XotQLCIX3McRic9OJdUnAdXa7sutwQ4nNrXwTSazN4IphjA==}
+  '@anthropic-ai/claude-agent-sdk@0.3.250':
+    resolution: {integrity: sha512-qT/1cBZs0+xPsQfqVOnwIk6pNW8XBkTpQS5RAXKHYb2XYCKqYc0UmOaeiYU2WeI6HEZKORa5iCaAZyKWGluShw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
       '@modelcontextprotocol/sdk': '>=1.30.0'
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.121.0':
-    resolution: {integrity: sha512-WFzwcH8l49CZHv0vQ9QQT51VJ1/DLDQfNSs9awpGlnKBdaSnqtdZa+tw/3cxxosTPIgK8uw1GqsJ2dSbCBD1Lg==}
+  '@anthropic-ai/sdk@0.122.0':
+    resolution: {integrity: sha512-GGPNftt0caaz9MDlmNQGHX8855Ojaduyy5pm9Sm1h7HalCn0cWNb5/bweadJF+4yzbal+QL6ztBa09WAAOzLmQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3102,46 +3102,46 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.247':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.250':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.247(@anthropic-ai/sdk@0.121.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.250(@anthropic-ai/sdk@0.122.0(zod@4.3.6))(@modelcontextprotocol/sdk@1.30.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.121.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.122.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.247
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.247
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.250
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.250
 
-  '@anthropic-ai/sdk@0.121.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.122.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- Updates `@anthropic-ai/claude-agent-sdk` from `0.3.247` to `0.3.250` and `@anthropic-ai/sdk` from `^0.121.0` to `^0.122.0`.
- Refreshes Claude's tool registry: adds `ListAgents` and MCP resource browsing tools, and removes retired `ShareOnboardingGuide`.
- Keeps OpenCode translation quiet for the newly recognized Claude-only tools.
- Publishes `cyrus-core@0.2.71-test.0` under the npm `test` dist-tag for hosted validation; npm `latest` remains `0.2.70`.

## Verification

- `pnpm build`
- `pnpm test:packages:run` (all package suites pass; edge-worker 780 passed, 1 skipped)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm audit` (no known vulnerabilities)
- `./scripts/extract-claude-tools.sh`

## Linear

[CYPACK-1481](https://linear.app/ceedar/issue/CYPACK-1481/update-anthropic-aiclaude-agent-sdk-and-anthropic-aisdk-to-the-latest)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
