### PR TITLE
fix(core): make EdgeWorker state saves atomic (write temp + rename)

### DIFF
--- a/packages/core/src/PersistenceManager.ts
+++ b/packages/core/src/PersistenceManager.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type {
@@ -121,7 +121,13 @@ export class PersistenceManager {
 				savedAt: new Date().toISOString(),
 				state,
 			};
-			await writeFile(stateFile, JSON.stringify(stateData, null, 2), "utf8");
+			// Write-then-rename so the state file is always a complete document.
+			// A plain writeFile interrupted mid-write (SIGKILL, OOM kill, power
+			// loss) leaves truncated JSON that the next boot cannot parse, which
+			// orphans every in-flight session.
+			const tmpFile = `${stateFile}.tmp`;
+			await writeFile(tmpFile, JSON.stringify(stateData, null, 2), "utf8");
+			await rename(tmpFile, stateFile);
 		} catch (error) {
 			this.logger.error("Failed to save EdgeWorker state:", error);
 			throw error;
@@ -139,7 +145,13 @@ export class PersistenceManager {
 				return null;
 			}
 
-			const stateData = JSON.parse(await readFile(stateFile, "utf8"));
+			const rawState = await readFile(stateFile, "utf8");
+			if (!rawState.trim()) {
+				// deleteStateFile clears the file rather than unlinking it; an
+				// empty file is "no state", not a parse error.
+				return null;
+			}
+			const stateData = JSON.parse(rawState);
 
 			// Validate state structure exists
 			if (!stateData.state) {

--- a/packages/core/test/PersistenceManager.atomic-write.test.ts
+++ b/packages/core/test/PersistenceManager.atomic-write.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for atomic EdgeWorker state persistence.
+ *
+ * The state file is rewritten in full on every save. A plain writeFile can be
+ * interrupted (SIGKILL, OOM kill, power loss) leaving a truncated file, which
+ * the next boot fails to parse — orphaning every in-flight session. Saves must
+ * therefore go through a temp file + rename, and loads must tolerate the
+ * artifacts of past crashes.
+ *
+ * These tests use the real filesystem (a fresh temp dir per test), unlike the
+ * migration tests which mock node:fs.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ILogger } from "../src/logging/index.js";
+import {
+	PERSISTENCE_VERSION,
+	PersistenceManager,
+	type SerializableEdgeWorkerState,
+} from "../src/PersistenceManager.js";
+
+const sampleState: SerializableEdgeWorkerState = {
+	agentSessions: {
+		"session-1": {
+			id: "session-1",
+		} as never,
+	},
+	agentSessionEntries: { "session-1": [] },
+	childToParentAgentSession: {},
+	issueRepositoryCache: { "issue-1": ["repo-1"] },
+};
+
+function stubLogger(): ILogger {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		child: vi.fn().mockReturnThis(),
+	} as unknown as ILogger;
+}
+
+describe("PersistenceManager atomic writes", () => {
+	let dir: string;
+	let logger: ILogger;
+	let manager: PersistenceManager;
+
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cyrus-persistence-test-"));
+		logger = stubLogger();
+		manager = new PersistenceManager(dir, logger);
+	});
+
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("round-trips state through save and load", async () => {
+		await manager.saveEdgeWorkerState(sampleState);
+		const loaded = await manager.loadEdgeWorkerState();
+		expect(loaded).toEqual(sampleState);
+	});
+
+	it("leaves no temp file behind after a save", async () => {
+		await manager.saveEdgeWorkerState(sampleState);
+		await manager.saveEdgeWorkerState(sampleState);
+		const files = await readdir(dir);
+		expect(files).toEqual(["edge-worker-state.json"]);
+	});
+
+	it("persists complete, parseable JSON", async () => {
+		await manager.saveEdgeWorkerState(sampleState);
+		const raw = await readFile(join(dir, "edge-worker-state.json"), "utf8");
+		const parsed = JSON.parse(raw);
+		expect(parsed.version).toBe(PERSISTENCE_VERSION);
+		expect(parsed.state).toEqual(sampleState);
+	});
+
+	it("treats an intentionally cleared state file as no state, not an error", async () => {
+		await manager.saveEdgeWorkerState(sampleState);
+		await manager.deleteStateFile();
+
+		const loaded = await manager.loadEdgeWorkerState();
+
+		expect(loaded).toBeNull();
+		expect(logger.error).not.toHaveBeenCalled();
+	});
+
+	it("returns null (without throwing) for a truncated state file", async () => {
+		// The artifact the atomic write prevents going forward; loads must still
+		// recover from one produced by an older version.
+		await writeFile(
+			join(dir, "edge-worker-state.json"),
+			'{"version":"4.0","savedAt":"2026-01-01T00:00:00.000Z","state":{"agentSess',
+			"utf8",
+		);
+		const loaded = await manager.loadEdgeWorkerState();
+		expect(loaded).toBeNull();
+	});
+
+	it("ignores a stale temp file from a previous crashed save", async () => {
+		await manager.saveEdgeWorkerState(sampleState);
+		// A save killed between writeFile(tmp) and rename leaves this behind.
+		await writeFile(
+			join(dir, "edge-worker-state.json.tmp"),
+			'{"version":"4.0","sav',
+			"utf8",
+		);
+
+		const loaded = await manager.loadEdgeWorkerState();
+
+		expect(loaded).toEqual(sampleState);
+		// The next save must overwrite the stale temp file, not trip over it.
+		await manager.saveEdgeWorkerState(sampleState);
+		expect(existsSync(join(dir, "edge-worker-state.json.tmp"))).toBe(false);
+	});
+});

--- a/packages/core/test/PersistenceManager.migration.test.ts
+++ b/packages/core/test/PersistenceManager.migration.test.ts
@@ -18,6 +18,7 @@ vi.mock("node:fs", () => ({
 vi.mock("node:fs/promises", () => ({
 	mkdir: vi.fn(),
 	readFile: vi.fn(),
+	rename: vi.fn(),
 	writeFile: vi.fn(),
 }));
 


### PR DESCRIPTION
## Problem

`PersistenceManager.saveEdgeWorkerState` rewrites the full `edge-worker-state.json` (ours is ~2.8MB) with a bare `writeFile`. A process killed mid-write — SIGKILL, kernel OOM kill, power loss — leaves a truncated JSON document, and the next boot logs:

```
[ERROR] [PersistenceManager] Failed to load EdgeWorker state: SyntaxError: Unexpected end of JSON input
```

…and starts with no state, silently orphaning every in-flight session.

We hit this in production on 2026-08-28: the kernel OOM-killed our edge worker (v0.2.66) while ~39 sessions were live; systemd SIGKILLed the unit mid-save, the state file was truncated, and every session became a permanently stalled zombie in Linear.

## Fix

- `saveEdgeWorkerState` now writes to `edge-worker-state.json.tmp` and `rename`s it over the real file, so the state file on disk is always a complete document (rename is atomic on the same filesystem).
- `loadEdgeWorkerState` treats an empty state file as "no state" instead of a JSON parse error — matching `deleteStateFile`'s clear-instead-of-unlink behavior, which previously produced a spurious `Failed to load` error on the next boot after a state reset.
- Loads still recover (return null) from truncated files written by older versions, and a stale `.tmp` left by a crashed save is simply overwritten by the next save.

## Test plan

- New `packages/core/test/PersistenceManager.atomic-write.test.ts` (real filesystem, temp dir per test): round-trip, no `.tmp` remnants, complete JSON on disk, cleared-file load without error, truncated-file recovery, stale-`.tmp` tolerance.
- Extended the existing `node:fs/promises` mock in the migration tests with `rename`.
- `pnpm --filter cyrus-core test`: 146/146 pass. Full workspace build + typecheck green (pre-commit hook).