### PR TITLE
feat(edge-worker): add maxConcurrentSessions cap on concurrent runner sessions

### DIFF
--- a/packages/core/schemas/EdgeConfig.json
+++ b/packages/core/schemas/EdgeConfig.json
@@ -653,6 +653,11 @@
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},
+		"maxConcurrentSessions": {
+			"type": "integer",
+			"exclusiveMinimum": 0,
+			"maximum": 9007199254740991
+		},
 		"slackThreadFollowing": {
 			"type": "boolean"
 		},

--- a/packages/core/schemas/EdgeConfigPayload.json
+++ b/packages/core/schemas/EdgeConfigPayload.json
@@ -647,6 +647,11 @@
 		"issueUpdateTrigger": {
 			"type": "boolean"
 		},
+		"maxConcurrentSessions": {
+			"type": "integer",
+			"exclusiveMinimum": 0,
+			"maximum": 9007199254740991
+		},
 		"slackThreadFollowing": {
 			"type": "boolean"
 		},

--- a/packages/core/src/config-schemas.ts
+++ b/packages/core/src/config-schemas.ts
@@ -526,6 +526,19 @@ export const EdgeConfigSchema = z.object({
 	issueUpdateTrigger: z.boolean().optional(),
 
 	/**
+	 * Maximum number of agent runner sessions allowed to execute concurrently
+	 * across all repositories and platforms. Additional session starts wait in
+	 * FIFO order for a free slot and begin automatically as running sessions
+	 * finish. Omit for unlimited (the historical behavior).
+	 *
+	 * Use this on hosts where an unbounded burst of webhook-driven sessions
+	 * can exhaust memory or CPU. Hot-reloads with the config file: raising the
+	 * limit admits queued sessions immediately; lowering it applies as
+	 * running sessions finish.
+	 */
+	maxConcurrentSessions: z.number().int().positive().optional(),
+
+	/**
 	 * Whether Cyrus follows along with all subsequent replies in a Slack thread
 	 * it has been @mentioned in (treating each reply as a follow-up prompt).
 	 * When false, Cyrus only responds to explicit @mentions. Defaults to true if

--- a/packages/edge-worker/src/ConfigManager.ts
+++ b/packages/edge-worker/src/ConfigManager.ts
@@ -56,6 +56,7 @@ const RELOAD_MERGED_KEYS = [
 	"strictMcpConfig",
 	"defaultDisallowedTools",
 	"issueUpdateTrigger",
+	"maxConcurrentSessions",
 	"slackThreadFollowing",
 	"prReviewTrigger",
 	"userAccessControl",
@@ -358,6 +359,9 @@ export class ConfigManager extends EventEmitter {
 				// otherwise keep current or default to true
 				issueUpdateTrigger:
 					parsedConfig.issueUpdateTrigger ?? this.config.issueUpdateTrigger,
+				maxConcurrentSessions:
+					parsedConfig.maxConcurrentSessions ??
+					this.config.maxConcurrentSessions,
 				// Slack thread following: use parsed value if explicitly set,
 				// otherwise keep current or default to true
 				slackThreadFollowing:

--- a/packages/edge-worker/src/EdgeWorker.ts
+++ b/packages/edge-worker/src/EdgeWorker.ts
@@ -165,6 +165,7 @@ import {
 	RepositoryRouter,
 	type RepositoryRouterDeps,
 } from "./RepositoryRouter.js";
+import { capRunnerStarts, SessionSemaphore } from "./RunnerConcurrency.js";
 import {
 	RunnerConfigBuilder,
 	resolveIssueMcpConfigPath,
@@ -243,6 +244,8 @@ export class EdgeWorker extends EventEmitter {
 	// Extracted service modules
 	private attachmentService: AttachmentService;
 	private runnerSelectionService: RunnerSelectionService;
+	/** Global cap on concurrently executing runner sessions (see maxConcurrentSessions). */
+	private runnerSlots: SessionSemaphore;
 	private toolPermissionResolver: ToolPermissionResolver;
 	private mcpConfigService: McpConfigService;
 	private runnerConfigBuilder: RunnerConfigBuilder;
@@ -567,6 +570,10 @@ export class EdgeWorker extends EventEmitter {
 			this.config.linearWorkspaces || {},
 		);
 		this.runnerSelectionService = new RunnerSelectionService(this.config);
+		this.runnerSlots = new SessionSemaphore(
+			this.config.maxConcurrentSessions ?? Number.POSITIVE_INFINITY,
+			(message) => this.logger.info(message),
+		);
 		this.toolPermissionResolver = new ToolPermissionResolver(
 			this.config,
 			this.logger,
@@ -663,6 +670,9 @@ export class EdgeWorker extends EventEmitter {
 				this.configManager.setConfig(changes.newConfig);
 				this.runnerSelectionService.setConfig(changes.newConfig);
 				this.toolPermissionResolver.setConfig(changes.newConfig);
+				this.runnerSlots.setLimit(
+					changes.newConfig.maxConcurrentSessions ?? Number.POSITIVE_INFINITY,
+				);
 			},
 		);
 		this.configManager.startConfigWatcher();
@@ -5447,8 +5457,23 @@ ${taskSection}`;
 
 	/**
 	 * Instantiate the appropriate runner for the given type.
+	 *
+	 * Every runner is wrapped so its `start()`/`startStreaming()` hold a
+	 * global concurrency slot for the session's lifetime — this is the single
+	 * choke point that makes `maxConcurrentSessions` cover Linear, GitHub,
+	 * GitLab, and chat sessions alike.
 	 */
 	private createRunnerForType(
+		runnerType: RunnerType,
+		config: AgentRunnerConfig,
+	): IAgentRunner {
+		return capRunnerStarts(
+			this.buildRunnerForType(runnerType, config),
+			this.runnerSlots,
+		);
+	}
+
+	private buildRunnerForType(
 		runnerType: RunnerType,
 		config: AgentRunnerConfig,
 	): IAgentRunner {

--- a/packages/edge-worker/src/RunnerConcurrency.ts
+++ b/packages/edge-worker/src/RunnerConcurrency.ts
@@ -1,0 +1,137 @@
+/**
+ * Global concurrency cap for agent runner sessions.
+ *
+ * Every runner created by the EdgeWorker resolves `start()` /
+ * `startStreaming()` only when its session finishes, so holding a semaphore
+ * slot for the duration of that promise bounds how many sessions execute at
+ * once. Hosts running many webhook-driven sessions use this to keep total
+ * runner memory/CPU inside what the machine can serve, instead of letting an
+ * unbounded burst of sessions take the whole process down (e.g. via the
+ * kernel OOM killer).
+ */
+
+import type { IAgentRunner } from "cyrus-core";
+
+/**
+ * Counting semaphore with FIFO waiters and a live-adjustable limit.
+ *
+ * `Number.POSITIVE_INFINITY` means uncapped — `acquire()` resolves
+ * immediately. Lowering the limit never interrupts running sessions; it
+ * simply stops admitting new ones until enough slots free up.
+ */
+export class SessionSemaphore {
+	private activeCount = 0;
+	private waiters: Array<() => void> = [];
+
+	constructor(
+		private limit: number,
+		private readonly onQueued?: (message: string) => void,
+	) {
+		if (Number.isNaN(limit) || limit < 1) {
+			throw new Error(
+				`SessionSemaphore limit must be >= 1 or Infinity, got ${limit}`,
+			);
+		}
+	}
+
+	get active(): number {
+		return this.activeCount;
+	}
+
+	get waiting(): number {
+		return this.waiters.length;
+	}
+
+	get currentLimit(): number {
+		return this.limit;
+	}
+
+	acquire(): Promise<void> {
+		if (this.activeCount < this.limit) {
+			this.activeCount++;
+			return Promise.resolve();
+		}
+		return new Promise<void>((resolve) => {
+			this.waiters.push(resolve);
+			this.onQueued?.(
+				`Session start queued: ${this.activeCount} running at the ` +
+					`maxConcurrentSessions limit of ${this.limit}, ` +
+					`${this.waiters.length} waiting`,
+			);
+		});
+	}
+
+	release(): void {
+		if (this.activeCount === 0) {
+			// A release with nothing active is a bookkeeping bug in the caller;
+			// clamp rather than let the count go negative and over-admit later.
+			return;
+		}
+		this.activeCount--;
+		this.admitWaiters();
+	}
+
+	/**
+	 * Adjust the limit at runtime (config hot-reload). Raising it admits
+	 * queued sessions immediately; lowering it applies as sessions finish.
+	 */
+	setLimit(limit: number): void {
+		if (Number.isNaN(limit) || limit < 1) {
+			throw new Error(
+				`SessionSemaphore limit must be >= 1 or Infinity, got ${limit}`,
+			);
+		}
+		this.limit = limit;
+		this.admitWaiters();
+	}
+
+	private admitWaiters(): void {
+		while (this.waiters.length > 0 && this.activeCount < this.limit) {
+			this.activeCount++;
+			const next = this.waiters.shift();
+			next?.();
+		}
+	}
+}
+
+/**
+ * Wrap a runner so `start()` and `startStreaming()` hold a semaphore slot for
+ * their full duration. Both resolve when the session completes, so the slot
+ * is held for the session's lifetime and released on success and failure
+ * alike. Follow-up messages streamed into an already-started session
+ * (`addStreamMessage`) are untouched — the session already holds its slot.
+ *
+ * The wrapper is a Proxy rather than an instance mutation: the underlying
+ * runner is never modified, every other property forwards through unchanged,
+ * and the original methods stay observable (e.g. as test spies).
+ */
+export function capRunnerStarts(
+	runner: IAgentRunner,
+	semaphore: SessionSemaphore,
+): IAgentRunner {
+	const gate = async <T>(run: () => Promise<T>): Promise<T> => {
+		await semaphore.acquire();
+		try {
+			return await run();
+		} finally {
+			semaphore.release();
+		}
+	};
+
+	return new Proxy(runner, {
+		get(target, property, receiver) {
+			if (property === "start") {
+				return (prompt: string) => gate(() => target.start(prompt));
+			}
+			if (
+				property === "startStreaming" &&
+				typeof target.startStreaming === "function"
+			) {
+				return (initialPrompt?: string) =>
+					// biome-ignore lint/style/noNonNullAssertion: guarded by the typeof check above
+					gate(() => target.startStreaming!(initialPrompt));
+			}
+			return Reflect.get(target, property, receiver);
+		},
+	});
+}

--- a/packages/edge-worker/test/RunnerConcurrency.test.ts
+++ b/packages/edge-worker/test/RunnerConcurrency.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for the global session concurrency cap (maxConcurrentSessions).
+ *
+ * Runners resolve start()/startStreaming() when the session finishes, so
+ * holding a semaphore slot across that promise bounds concurrent sessions.
+ */
+
+import type { AgentSessionInfo, IAgentRunner } from "cyrus-core";
+import { describe, expect, it, vi } from "vitest";
+import { capRunnerStarts, SessionSemaphore } from "../src/RunnerConcurrency.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+const sessionInfo = (id: string): AgentSessionInfo =>
+	({ sessionId: id }) as AgentSessionInfo;
+
+/** A runner whose start()/startStreaming() completion the test controls. */
+function fakeRunner(streaming: boolean) {
+	const startGate = deferred<AgentSessionInfo>();
+	const streamingGate = deferred<AgentSessionInfo>();
+	const started = vi.fn(() => startGate.promise);
+	const startedStreaming = vi.fn(() => streamingGate.promise);
+	const runner = {
+		supportsStreamingInput: streaming,
+		start: started,
+		...(streaming ? { startStreaming: startedStreaming } : {}),
+	} as unknown as IAgentRunner;
+	return { runner, started, startedStreaming, startGate, streamingGate };
+}
+
+async function settled(): Promise<void> {
+	// Let queued microtasks (semaphore admissions) run.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("SessionSemaphore", () => {
+	it("admits immediately below the limit and queues at it", async () => {
+		const semaphore = new SessionSemaphore(2);
+		await semaphore.acquire();
+		await semaphore.acquire();
+		expect(semaphore.active).toBe(2);
+
+		let third = false;
+		const pending = semaphore.acquire().then(() => {
+			third = true;
+		});
+		await settled();
+		expect(third).toBe(false);
+		expect(semaphore.waiting).toBe(1);
+
+		semaphore.release();
+		await pending;
+		expect(third).toBe(true);
+		expect(semaphore.active).toBe(2);
+		expect(semaphore.waiting).toBe(0);
+	});
+
+	it("wakes waiters in FIFO order", async () => {
+		const semaphore = new SessionSemaphore(1);
+		await semaphore.acquire();
+
+		const order: number[] = [];
+		const first = semaphore.acquire().then(() => order.push(1));
+		const second = semaphore.acquire().then(() => order.push(2));
+
+		semaphore.release();
+		await first;
+		semaphore.release();
+		await second;
+		expect(order).toEqual([1, 2]);
+	});
+
+	it("never blocks when the limit is Infinity", async () => {
+		const semaphore = new SessionSemaphore(Number.POSITIVE_INFINITY);
+		for (let i = 0; i < 100; i++) {
+			await semaphore.acquire();
+		}
+		expect(semaphore.active).toBe(100);
+		expect(semaphore.waiting).toBe(0);
+	});
+
+	it("admits queued waiters when the limit is raised", async () => {
+		const semaphore = new SessionSemaphore(1);
+		await semaphore.acquire();
+		let admitted = false;
+		const pending = semaphore.acquire().then(() => {
+			admitted = true;
+		});
+		await settled();
+		expect(admitted).toBe(false);
+
+		semaphore.setLimit(2);
+		await pending;
+		expect(admitted).toBe(true);
+	});
+
+	it("applies a lowered limit as sessions finish", async () => {
+		const semaphore = new SessionSemaphore(2);
+		await semaphore.acquire();
+		await semaphore.acquire();
+
+		semaphore.setLimit(1);
+		semaphore.release();
+		// Still at the (new) limit: one active, so a new acquire queues.
+		let admitted = false;
+		semaphore.acquire().then(() => {
+			admitted = true;
+		});
+		await settled();
+		expect(admitted).toBe(false);
+		expect(semaphore.active).toBe(1);
+	});
+
+	it("reports queueing through the onQueued callback", async () => {
+		const onQueued = vi.fn();
+		const semaphore = new SessionSemaphore(1, onQueued);
+		await semaphore.acquire();
+		expect(onQueued).not.toHaveBeenCalled();
+		void semaphore.acquire();
+		expect(onQueued).toHaveBeenCalledOnce();
+	});
+
+	it("rejects invalid limits", () => {
+		expect(() => new SessionSemaphore(0)).toThrow();
+		expect(() => new SessionSemaphore(Number.NaN)).toThrow();
+		expect(() => new SessionSemaphore(1).setLimit(0)).toThrow();
+	});
+});
+
+describe("capRunnerStarts", () => {
+	it("holds a slot for the full duration of start()", async () => {
+		const semaphore = new SessionSemaphore(1);
+		const first = fakeRunner(false);
+		const second = fakeRunner(false);
+		const firstWrapped = capRunnerStarts(first.runner, semaphore);
+		const secondWrapped = capRunnerStarts(second.runner, semaphore);
+
+		const firstDone = firstWrapped.start("one");
+		const secondDone = secondWrapped.start("two");
+		await settled();
+
+		expect(first.started).toHaveBeenCalledOnce();
+		// Second session must not begin while the first is still running.
+		expect(second.started).not.toHaveBeenCalled();
+
+		first.startGate.resolve(sessionInfo("s1"));
+		await firstDone;
+		await settled();
+		expect(second.started).toHaveBeenCalledOnce();
+
+		second.startGate.resolve(sessionInfo("s2"));
+		await expect(secondDone).resolves.toEqual(sessionInfo("s2"));
+	});
+
+	it("gates startStreaming() the same way", async () => {
+		const semaphore = new SessionSemaphore(1);
+		const first = fakeRunner(true);
+		const second = fakeRunner(true);
+		const firstWrapped = capRunnerStarts(first.runner, semaphore);
+		const secondWrapped = capRunnerStarts(second.runner, semaphore);
+
+		const firstDone = firstWrapped.startStreaming?.("one");
+		void secondWrapped.startStreaming?.("two");
+		await settled();
+
+		expect(first.startedStreaming).toHaveBeenCalledOnce();
+		expect(second.startedStreaming).not.toHaveBeenCalled();
+
+		first.streamingGate.resolve(sessionInfo("s1"));
+		await firstDone;
+		await settled();
+		expect(second.startedStreaming).toHaveBeenCalledOnce();
+	});
+
+	it("releases the slot when a session fails", async () => {
+		const semaphore = new SessionSemaphore(1);
+		const failing = fakeRunner(false);
+		const next = fakeRunner(false);
+		const failingWrapped = capRunnerStarts(failing.runner, semaphore);
+		const nextWrapped = capRunnerStarts(next.runner, semaphore);
+
+		const failingDone = failingWrapped.start("boom");
+		const nextDone = nextWrapped.start("after");
+		await settled();
+
+		failing.startGate.reject(new Error("session crashed"));
+		await expect(failingDone).rejects.toThrow("session crashed");
+		await settled();
+
+		expect(next.started).toHaveBeenCalledOnce();
+		next.startGate.resolve(sessionInfo("s2"));
+		await nextDone;
+		expect(semaphore.active).toBe(0);
+	});
+
+	it("does not add startStreaming to runners without it", () => {
+		const semaphore = new SessionSemaphore(1);
+		const plain = fakeRunner(false);
+		const wrapped = capRunnerStarts(plain.runner, semaphore);
+		expect(wrapped.startStreaming).toBeUndefined();
+	});
+
+	it("passes prompts and results through unchanged", async () => {
+		const semaphore = new SessionSemaphore(Number.POSITIVE_INFINITY);
+		const { runner, started, startGate } = fakeRunner(false);
+		const wrapped = capRunnerStarts(runner, semaphore);
+
+		const done = wrapped.start("the prompt");
+		startGate.resolve(sessionInfo("s1"));
+		await expect(done).resolves.toEqual(sessionInfo("s1"));
+		expect(started).toHaveBeenCalledWith("the prompt");
+	});
+
+	it("leaves the underlying runner untouched and its spies observable", async () => {
+		// Regression guard: an earlier draft mutated runner.start in place,
+		// which broke every test that asserts on a mock runner's methods.
+		const semaphore = new SessionSemaphore(Number.POSITIVE_INFINITY);
+		const { runner, started, startGate } = fakeRunner(false);
+		const originalStart = runner.start;
+		const wrapped = capRunnerStarts(runner, semaphore);
+
+		const done = wrapped.start("p");
+		startGate.resolve(sessionInfo("s"));
+		await done;
+
+		expect(runner.start).toBe(originalStart);
+		expect(runner.start).toHaveBeenCalledOnce();
+		expect(started).toHaveBeenCalledOnce();
+	});
+
+	it("forwards other members through to the underlying runner", () => {
+		const semaphore = new SessionSemaphore(1);
+		const addStreamMessage = vi.fn();
+		const runner = {
+			supportsStreamingInput: true,
+			start: vi.fn(),
+			startStreaming: vi.fn(),
+			addStreamMessage,
+		} as unknown as IAgentRunner;
+		const wrapped = capRunnerStarts(runner, semaphore);
+
+		expect(wrapped.supportsStreamingInput).toBe(true);
+		wrapped.addStreamMessage?.("follow-up");
+		expect(addStreamMessage).toHaveBeenCalledWith("follow-up");
+	});
+});


### PR DESCRIPTION
## Problem

There is currently no bound on how many agent runner sessions execute concurrently. On a self-hosted worker receiving webhook-driven work (Linear kickoffs, GitHub PR events, stall-watchdog nudges), bursts of 30–40 concurrent sessions — each a multi-GB node/codex process running builds and test suites — can exhaust host memory. On our production host (32GB) the kernel OOM killer then took the whole edge worker down **22 times in 14 days**, killing every in-flight session each time (and, until #1444, corrupting the persisted state on the way down).

## Approach

New optional `EdgeConfig` field `maxConcurrentSessions` (omit = unlimited, the historical behavior).

- Enforced by a small FIFO `SessionSemaphore` (`packages/edge-worker/src/RunnerConcurrency.ts`) wrapped around every runner at the single choke point, `createRunnerForType`, so Linear, GitHub, GitLab, and chat sessions all count against one limit.
- A runner's `start()` / `startStreaming()` resolve when the session finishes, so a slot is held for the session's full lifetime and released on success and failure alike. Queued sessions log their queue position and start automatically as slots free up. Messages streamed into an already-running session (`addStreamMessage`) are untouched.
- The wrapper is a `Proxy` — the underlying runner instance is never mutated and every other member forwards through unchanged (existing tests that spy on mock runner methods keep working; there's a regression test pinning this).
- Hot-reloads with the config file: the key is classified in `RELOAD_MERGED_KEYS`, merged in `loadConfigSafely`, and the `configChanged` handler calls `setLimit` — raising the limit admits queued sessions immediately, lowering applies as running sessions finish.

## Known consideration

A session that itself waits on child agent sessions can hold a slot while its children queue. Operators using orchestrator-style fan-out should set the limit comfortably above their expected fan-out depth; the field is opt-in so default behavior is unchanged.

## Test plan

- New `packages/edge-worker/test/RunnerConcurrency.test.ts` (14 tests): semaphore cap/FIFO/Infinity/limit-raise/limit-lower/queue-callback, gating of `start` and `startStreaming`, slot release on session failure, prompt/result passthrough, no `startStreaming` added to runners without it, spy observability, member forwarding.
- Full `cyrus-edge-worker` suite: 794 passed, 1 skipped (includes all existing EdgeWorker mock-runner tests). `cyrus-core` suite and JSON-schema regeneration green via the pre-commit hook.