### PR TITLE
Add GitHub CLI media guidance to agent prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Every agent session now explains how to attach local images and videos to GitHub issues, pull requests, and comments with GitHub CLI v2.99.0 or newer, independently of optional browser tooling. ([CYPACK-1490](https://linear.app/ceedar/issue/CYPACK-1490/add-this-to-the-system-prompt), [#1453](https://github.com/cyrusagents/cyrus/pull/1453))
+
 ### Fixed
 - EdgeWorker state saves are now atomic, preventing a process interrupted during a save from leaving a truncated state file that strands in-flight sessions; empty and legacy-truncated state files also recover cleanly. Thanks @connor-tembo for the contribution. ([CYPACK-1486](https://linear.app/ceedar/issue/CYPACK-1486/can-you-add-a-changelog-entry-for-this), [#1444](https://github.com/cyrusagents/cyrus/pull/1444))
 

--- a/packages/edge-worker/src/RunnerConfigBuilder.ts
+++ b/packages/edge-worker/src/RunnerConfigBuilder.ts
@@ -24,6 +24,7 @@ import { buildPrMarkerHook } from "./hooks/PrMarkerHook.js";
 import { appendBrowserUseAddendum } from "./prompts/browserUsePromptAddendum.js";
 import { appendCloudRuntimeAddendum } from "./prompts/cloudRuntimePromptAddendum.js";
 import { appendFailureModeAddendum } from "./prompts/failureModePromptAddendum.js";
+import { appendGitHubCliMediaAddendum } from "./prompts/githubCliMediaPromptAddendum.js";
 
 /**
  * Subset of McpConfigService consumed by RunnerConfigBuilder.
@@ -297,7 +298,11 @@ export class RunnerConfigBuilder {
 			cyrusHome: input.cyrusHome,
 			autoMemoryDirectory,
 			appendSystemPrompt: appendCloudRuntimeAddendum(
-				appendBrowserUseAddendum(appendFailureModeAddendum(input.systemPrompt)),
+				appendGitHubCliMediaAddendum(
+					appendBrowserUseAddendum(
+						appendFailureModeAddendum(input.systemPrompt),
+					),
+				),
 			),
 			...(mcpConfig ? { mcpConfig } : {}),
 			...(mcpConfigPath ? { mcpConfigPath } : {}),
@@ -445,7 +450,11 @@ export class RunnerConfigBuilder {
 			mcpConfig,
 			strictMcpConfig: input.strictMcpConfig ?? true,
 			appendSystemPrompt: appendCloudRuntimeAddendum(
-				appendBrowserUseAddendum(appendFailureModeAddendum(input.systemPrompt)),
+				appendGitHubCliMediaAddendum(
+					appendBrowserUseAddendum(
+						appendFailureModeAddendum(input.systemPrompt),
+					),
+				),
 			),
 			// Priority order: label override > repository config > global default
 			model: finalModel,

--- a/packages/edge-worker/src/prompts/githubCliMediaPromptAddendum.ts
+++ b/packages/edge-worker/src/prompts/githubCliMediaPromptAddendum.ts
@@ -1,0 +1,31 @@
+/**
+ * System-prompt addendum describing GitHub CLI media attachments.
+ *
+ * Unlike environment-specific tooling addenda, this guidance is included in
+ * every agent session so agents can use the capability whenever an appropriate
+ * GitHub CLI version is available.
+ */
+export const GITHUB_CLI_MEDIA_PROMPT_ADDENDUM = `
+<github_cli_media>
+GitHub CLI v2.99.0+ has a repeatable \`--attach <path>\` flag that uploads a
+local image or video and references it inline in an issue, pull request, or
+comment body. This is generally available to users on all GitHub plans. Use it
+with \`gh issue create|edit|comment\` or
+\`gh pr create|edit|comment\`, for example
+\`gh pr comment --attach ./screenshot.png\`.
+
+Check \`gh --version\` before using \`--attach\`. If the installed version is
+older than v2.99.0, recommend that the user update GitHub CLI. See
+https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/
+for supported formats, limits, alt text, and more examples.
+</github_cli_media>
+`.trim();
+
+/** Append the GitHub CLI media guidance to a system prompt fragment. */
+export function appendGitHubCliMediaAddendum(
+	existing: string | undefined | null,
+): string {
+	const base = (existing ?? "").trimEnd();
+	if (base.length === 0) return GITHUB_CLI_MEDIA_PROMPT_ADDENDUM;
+	return `${base}\n\n${GITHUB_CLI_MEDIA_PROMPT_ADDENDUM}`;
+}

--- a/packages/edge-worker/test/RunnerConfigBuilder.prompt-addenda.test.ts
+++ b/packages/edge-worker/test/RunnerConfigBuilder.prompt-addenda.test.ts
@@ -1,0 +1,114 @@
+import type { ILogger } from "cyrus-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { BROWSER_USE_PROMPT_ADDENDUM } from "../src/prompts/browserUsePromptAddendum.js";
+import { FAILURE_MODE_PROMPT_ADDENDUM } from "../src/prompts/failureModePromptAddendum.js";
+import { GITHUB_CLI_MEDIA_PROMPT_ADDENDUM } from "../src/prompts/githubCliMediaPromptAddendum.js";
+import {
+	type IChatToolResolver,
+	type IMcpConfigProvider,
+	type IRunnerSelector,
+	RunnerConfigBuilder,
+} from "../src/RunnerConfigBuilder.js";
+
+const silentLogger: ILogger = {
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+} as unknown as ILogger;
+
+function makeBuilder(): RunnerConfigBuilder {
+	const chatToolResolver: IChatToolResolver = {
+		buildChatAllowedTools: () => ["Read(**)"],
+	};
+	const mcpConfigProvider: IMcpConfigProvider = {
+		buildMcpConfig: () => ({}),
+		buildMergedMcpConfigPath: () => undefined,
+	};
+	const runnerSelector: IRunnerSelector = {
+		determineRunnerSelection: () => ({ runnerType: "claude" as const }),
+		getDefaultRunner: () => "claude",
+		getDefaultModelForRunner: () => "",
+		getDefaultFallbackModelForRunner: () => "",
+	};
+	return new RunnerConfigBuilder(
+		chatToolResolver,
+		mcpConfigProvider,
+		runnerSelector,
+	);
+}
+
+function buildChatPrompt(builder: RunnerConfigBuilder): string | undefined {
+	return builder.buildChatConfig({
+		workspacePath: "/tmp/chat-workspace",
+		workspaceName: "chat-thread",
+		systemPrompt: "Base prompt.",
+		sessionId: "chat-session",
+		cyrusHome: "/tmp/cyrus",
+		platformName: "slack",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+	}).appendSystemPrompt;
+}
+
+function buildIssuePrompt(builder: RunnerConfigBuilder): string | undefined {
+	return builder.buildIssueConfig({
+		session: {
+			issueId: "issue-1",
+			workspace: { path: "/tmp/worktree" },
+			issue: { identifier: "CYPACK-1490" },
+		} as any,
+		repository: { id: "repo-1", path: "/tmp/repo" } as any,
+		sessionId: "issue-session",
+		systemPrompt: "Base prompt.",
+		allowedTools: ["Read(**)"],
+		allowedDirectories: ["/tmp/worktree"],
+		disallowedTools: [],
+		labels: [],
+		cyrusHome: "/tmp/cyrus",
+		logger: silentLogger,
+		onMessage: () => {},
+		onError: () => {},
+		requireLinearWorkspaceId: () => "workspace-1",
+	}).config.appendSystemPrompt;
+}
+
+describe("RunnerConfigBuilder prompt addenda", () => {
+	const originalBrowserUse = process.env.CYRUS_BROWSER_USE_ENABLED;
+	const originalCloudRuntime = process.env.CYRUS_CLOUD_RUNTIME;
+
+	beforeEach(() => {
+		delete process.env.CYRUS_BROWSER_USE_ENABLED;
+		delete process.env.CYRUS_CLOUD_RUNTIME;
+	});
+
+	afterEach(() => {
+		if (originalBrowserUse === undefined)
+			delete process.env.CYRUS_BROWSER_USE_ENABLED;
+		else process.env.CYRUS_BROWSER_USE_ENABLED = originalBrowserUse;
+		if (originalCloudRuntime === undefined)
+			delete process.env.CYRUS_CLOUD_RUNTIME;
+		else process.env.CYRUS_CLOUD_RUNTIME = originalCloudRuntime;
+	});
+
+	it("always adds GitHub media guidance to chat prompts while browser use remains disabled", () => {
+		expect(buildChatPrompt(makeBuilder())).toBe(
+			`Base prompt.\n\n${FAILURE_MODE_PROMPT_ADDENDUM}\n\n${GITHUB_CLI_MEDIA_PROMPT_ADDENDUM}`,
+		);
+	});
+
+	it("always adds GitHub media guidance to issue prompts while browser use remains disabled", () => {
+		expect(buildIssuePrompt(makeBuilder())).toBe(
+			`Base prompt.\n\n${FAILURE_MODE_PROMPT_ADDENDUM}\n\n${GITHUB_CLI_MEDIA_PROMPT_ADDENDUM}`,
+		);
+	});
+
+	it("adds browser guidance separately when its environment flag is enabled", () => {
+		process.env.CYRUS_BROWSER_USE_ENABLED = "true";
+
+		expect(buildChatPrompt(makeBuilder())).toBe(
+			`Base prompt.\n\n${FAILURE_MODE_PROMPT_ADDENDUM}\n\n${BROWSER_USE_PROMPT_ADDENDUM}\n\n${GITHUB_CLI_MEDIA_PROMPT_ADDENDUM}`,
+		);
+	});
+});

--- a/packages/edge-worker/test/githubCliMediaPromptAddendum.test.ts
+++ b/packages/edge-worker/test/githubCliMediaPromptAddendum.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+	appendGitHubCliMediaAddendum,
+	GITHUB_CLI_MEDIA_PROMPT_ADDENDUM,
+} from "../src/prompts/githubCliMediaPromptAddendum.js";
+
+describe("GitHub CLI media prompt addendum", () => {
+	it("contains the complete GitHub CLI media guidance", () => {
+		expect(GITHUB_CLI_MEDIA_PROMPT_ADDENDUM).toBe(`<github_cli_media>
+GitHub CLI v2.99.0+ has a repeatable \`--attach <path>\` flag that uploads a
+local image or video and references it inline in an issue, pull request, or
+comment body. This is generally available to users on all GitHub plans. Use it
+with \`gh issue create|edit|comment\` or
+\`gh pr create|edit|comment\`, for example
+\`gh pr comment --attach ./screenshot.png\`.
+
+Check \`gh --version\` before using \`--attach\`. If the installed version is
+older than v2.99.0, recommend that the user update GitHub CLI. See
+https://github.blog/changelog/2026-09-01-github-cli-media-in-issues-pull-requests-and-comments/
+for supported formats, limits, alt text, and more examples.
+</github_cli_media>`);
+	});
+
+	it("appends the guidance with a blank-line separator", () => {
+		expect(appendGitHubCliMediaAddendum("You are Cyrus.")).toBe(
+			`You are Cyrus.\n\n${GITHUB_CLI_MEDIA_PROMPT_ADDENDUM}`,
+		);
+	});
+
+	it("returns the guidance verbatim with no base prompt", () => {
+		expect(appendGitHubCliMediaAddendum(undefined)).toBe(
+			GITHUB_CLI_MEDIA_PROMPT_ADDENDUM,
+		);
+		expect(appendGitHubCliMediaAddendum(null)).toBe(
+			GITHUB_CLI_MEDIA_PROMPT_ADDENDUM,
+		);
+		expect(appendGitHubCliMediaAddendum("")).toBe(
+			GITHUB_CLI_MEDIA_PROMPT_ADDENDUM,
+		);
+	});
+});


### PR DESCRIPTION
Assignee: @Connoropolous ([connor](https://linear.app/ceedar/profiles/connor))

## Summary

- add a dedicated GitHub CLI media system-prompt block to every issue and chat agent session
- document the repeatable `--attach` flag, GitHub CLI v2.99.0 minimum, version check and update recommendation, availability across GitHub plans, supported commands, and usage link
- keep the existing `<browser_use>` addendum unchanged and controlled by `CYRUS_BROWSER_USE_ENABLED`

## Testing

- `pnpm test:packages:run`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- 12 focused tests covering exact GitHub guidance and full issue/chat prompt composition with browser use both disabled and enabled

Linear: [CYPACK-1490](https://linear.app/ceedar/issue/CYPACK-1490/add-this-to-the-system-prompt)

---
> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->
