### PR TITLE
chore: prepare v0.2.71 release (CYPACK-1495)

### DIFF
--- a/CHANGELOG.internal.md
+++ b/CHANGELOG.internal.md
@@ -4,6 +4,8 @@ This changelog documents internal development changes, refactors, tooling update
 
 ## [Unreleased]
 
+## [0.2.71] - 2026-09-04
+
 ### Changed
 - Recorded, after the fact, why #1426 removed the `linear_agent_session_create` and `linear_agent_session_create_on_comment` cyrus-tools: they allowed concurrent child sessions to be started on the same issue. That removal also silently dropped the only runtime caller of `GlobalSessionRegistry.setParentSession`, breaking parent resumption. `EdgeWorker.linkChildSessionToParentIssueSession` now derives the child-to-parent session link from Linear's issue hierarchy on `AgentSessionEvent/created` (and after repository selection), so the removed tools stay removed. ([#1454](https://github.com/cyrusagents/cyrus/pull/1454))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.71] - 2026-09-04
+
 ### Added
 - Every agent session now explains how to attach local images and videos to GitHub issues, pull requests, and comments with GitHub CLI v2.99.0 or newer, independently of optional browser tooling. ([CYPACK-1490](https://linear.app/ceedar/issue/CYPACK-1490/add-this-to-the-system-prompt), [#1453](https://github.com/cyrusagents/cyrus/pull/1453))
 
@@ -28,6 +30,56 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 - Patched eight newly reported Cyrus CLI dependency advisories so `pnpm audit` reports no known vulnerabilities, while replacing the redundant `fast-uri` override with upstream-compatible direct dependency updates. ([CYPACK-1492](https://linear.app/ceedar/issue/CYPACK-1492/address-open-security-patches-for-cyrus-cli), [#1456](https://github.com/cyrusagents/cyrus/pull/1456))
+
+### Packages
+
+#### cyrus-cloudflare-tunnel-client
+- cyrus-cloudflare-tunnel-client@0.2.71
+
+#### cyrus-mcp-tools
+- cyrus-mcp-tools@0.2.71
+
+#### cyrus-core
+- cyrus-core@0.2.71
+
+#### cyrus-claude-runner
+- cyrus-claude-runner@0.2.71
+
+#### cyrus-config-updater
+- cyrus-config-updater@0.2.71
+
+#### cyrus-linear-event-transport
+- cyrus-linear-event-transport@0.2.71
+
+#### cyrus-github-event-transport
+- cyrus-github-event-transport@0.2.71
+
+#### cyrus-gitlab-event-transport
+- cyrus-gitlab-event-transport@0.2.71
+
+#### cyrus-slack-event-transport
+- cyrus-slack-event-transport@0.2.71
+
+#### cyrus-simple-agent-runner
+- cyrus-simple-agent-runner@0.2.71
+
+#### cyrus-opencode-runner
+- cyrus-opencode-runner@0.2.71
+
+#### cyrus-codex-runner
+- cyrus-codex-runner@0.2.71
+
+#### cyrus-cursor-runner
+- cyrus-cursor-runner@0.2.71
+
+#### cyrus-gemini-runner
+- cyrus-gemini-runner@0.2.71
+
+#### cyrus-edge-worker
+- cyrus-edge-worker@0.2.71
+
+#### cyrus-ai
+- cyrus-ai@0.2.71
 
 ## [0.2.70] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ All notable changes to this project will be documented in this file.
 - cyrus-edge-worker@0.2.71
 
 #### cyrus-ai
-- cyrus-ai@0.2.71
+- cyrus-ai@0.2.71 ([CYPACK-1495](https://linear.app/ceedar/issue/CYPACK-1495/run-a-release), [#1461](https://github.com/cyrusagents/cyrus/pull/1461))
 
 ## [0.2.70] - 2026-08-27
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-ai",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "AI-powered Linear issue automation using Claude",
 	"main": "dist/src/app.js",
 	"types": "dist/src/app.d.ts",

--- a/apps/f1/test-drives/2026-09-04-cypack-1495-release-v0.2.71.md
+++ b/apps/f1/test-drives/2026-09-04-cypack-1495-release-v0.2.71.md
@@ -1,0 +1,98 @@
+# Test Drive: CYPACK-1495 Release v0.2.71
+
+**Date**: 2026-09-04
+**Goal**: Validate the local F1 issue, Claude session, and activity-rendering flow before publishing v0.2.71.
+**Test Repo**: `/private/tmp/f1-release-v0.2.71-3J3J5I/repo`
+**F1 Port**: `3600`
+**Reference Issue**: CYPACK-1495 (`run a release`)
+
+## Verification Results
+
+### Issue-Tracker
+- [x] Issue created
+- [x] Issue ID returned (`issue-1`, `DEF-1`)
+- [x] Issue metadata accessible through session view
+
+### EdgeWorker
+- [x] Session started (`session-1`)
+- [x] Repository selection completed
+- [x] Worktree created
+- [x] Activities tracked
+- [x] Claude processed the issue successfully
+- [x] Session stopped cleanly
+
+### Renderer
+- [x] Activity format correct (`elicitation`, `prompt`, `thought`, `action`, and `response`)
+- [x] Timestamps present
+- [x] Pagination works (`--limit 8 --offset 0` and `--offset 8`)
+- [x] Search works (`--search "TODO"`)
+
+## Session Log
+
+Built the F1 application and its transitive workspace dependencies:
+
+```bash
+pnpm --filter cyrus-f1... build
+```
+
+Result: all 16 selected workspace projects built successfully.
+
+Initialized a fresh repository and started F1 with the Claude runner:
+
+```bash
+apps/f1/f1 init-test-repo --path /private/tmp/f1-release-v0.2.71-3J3J5I/repo
+CYRUS_PORT=3600 \
+  CYRUS_DEFAULT_RUNNER=claude \
+  CYRUS_REPO_PATH=/private/tmp/f1-release-v0.2.71-3J3J5I/repo \
+  bun run apps/f1/server.ts
+CYRUS_PORT=3600 apps/f1/f1 ping
+CYRUS_PORT=3600 apps/f1/f1 status
+```
+
+Result: the server started cleanly on port 3600 and `status` returned `ready`. `ping` returned success but printed `Status: undefined`, the same pre-existing RPC/CLI field mismatch documented in the v0.2.70 release drive.
+
+Created an inspection-only issue, started a session, and resolved the repository-selection elicitation:
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 create-issue \
+  --title "Release v0.2.71 F1 validation" \
+  --description "Validate Cyrus v0.2.71 end to end by inspecting the configured test repository and reporting which rate limiter features are implemented or still TODO. Do not edit files."
+CYRUS_PORT=3600 apps/f1/f1 start-session --issue-id issue-1
+CYRUS_PORT=3600 apps/f1/f1 prompt-session \
+  --session-id session-1 \
+  --message "Use the configured F1 Test Repository for this issue."
+```
+
+Result: F1 created `issue-1` / `DEF-1` and `session-1`, routed the user selection to the configured F1 repository, created `/tmp/cyrus-f1-1788567210286/worktrees/DEF-1`, assigned Claude session `26d9c9be-21f4-44d9-97f4-645d208254ae`, and selected `claude/claude-sonnet-5`.
+
+The Claude-backed inspection completed successfully (`Session completed (subtype: success)`, 37 raw SDK messages). It rendered 15 coherent timeline activities and a final response that accurately distinguished the implemented token-bucket algorithm, in-memory storage, public API, and types from the TODO sliding-window algorithm, fixed-window algorithm, Redis adapter, unit tests, and extended docs. It also ran `npm run typecheck` successfully inside the generated repository and honored the instruction not to edit tracked files; `git status --short` remained empty at commit `4dbc9de`.
+
+Verified rendering, pagination, and search:
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 8 --offset 0
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --limit 8 --offset 8
+CYRUS_PORT=3600 apps/f1/f1 view-session --session-id session-1 --search "TODO"
+```
+
+Result: the full view showed all 15 activities, the two pagination windows returned 8 and 7 activities respectively, and search returned the seven matching action/thought/response activities.
+
+Stopped the completed session and shut down the server:
+
+```bash
+CYRUS_PORT=3600 apps/f1/f1 stop-session --session-id session-1
+```
+
+Result: the stop request succeeded and `SIGINT` produced a graceful shutdown after saving EdgeWorker state.
+
+## Non-blocking Observations
+
+1. `f1 ping` still prints `Status: undefined` although the request succeeds; this is the known field-name mismatch also observed in the v0.2.70 drive.
+2. `f1 version` fails because the compiled command looks for `apps/f1/dist/package.json`, which is not copied by the build. The server `/version` route was registered normally, and this auxiliary CLI defect is unrelated to the release contents.
+3. The agent's first `Skill(investigate)` invocation resolved to an unrelated user-level `~/.claude/skills/investigate` skill rather than Cyrus's bundled skill. The agent rejected its irrelevant side-effecting instructions, continued with direct read-only inspection, and completed successfully. This appears to be an ambient skill-name collision, not a regression in the v0.2.71 changes.
+4. The generated repository has no remote, so worktree setup logged a failed `git fetch origin` and correctly fell back to local `main`, as expected for the standard F1 scaffold.
+
+## Final Retrospective
+
+F1 validated the full local server, issue creation, repository-selection recovery, worktree creation, Claude execution, action/response rendering, pagination, search, final response, session stop, and graceful server shutdown paths for v0.2.71. All release pass criteria were met: the server started, the issue and session were created, activities were coherent, the agent produced a correct response, the session stopped cleanly, and no unhandled server or runner error occurred. The three auxiliary observations above are pre-existing or environment-specific and did not block the end-to-end flow. **v0.2.71 is validated for publishing.**

--- a/packages/claude-runner/package.json
+++ b/packages/claude-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-claude-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Claude CLI execution wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cloudflare-tunnel-client/package.json
+++ b/packages/cloudflare-tunnel-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cloudflare-tunnel-client",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Cloudflare tunnel client for receiving config updates and webhooks from cyrus-hosted",
 	"repository": {
 		"type": "git",

--- a/packages/codex-runner/package.json
+++ b/packages/codex-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-codex-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Codex CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/config-updater/package.json
+++ b/packages/config-updater/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-config-updater",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Configuration update handlers for Cyrus agent",
 	"repository": {
 		"type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-core",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Core business logic for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/cursor-runner/package.json
+++ b/packages/cursor-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-cursor-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Cursor Agent CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/edge-worker/package.json
+++ b/packages/edge-worker/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-edge-worker",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Unified edge worker for processing Linear issues with Claude",
 	"repository": {
 		"type": "git",

--- a/packages/gemini-runner/package.json
+++ b/packages/gemini-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gemini-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Gemini CLI process spawning and management for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/github-event-transport/package.json
+++ b/packages/github-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-github-event-transport",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "GitHub event transport for receiving and verifying forwarded GitHub webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/gitlab-event-transport/package.json
+++ b/packages/gitlab-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-gitlab-event-transport",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "GitLab event transport for receiving and verifying forwarded GitLab webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/linear-event-transport/package.json
+++ b/packages/linear-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-linear-event-transport",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Linear event transport for receiving and verifying Linear webhooks",
 	"repository": {
 		"type": "git",

--- a/packages/mcp-tools/package.json
+++ b/packages/mcp-tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-mcp-tools",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Runner-neutral MCP tool servers for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/opencode-runner/package.json
+++ b/packages/opencode-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-opencode-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "OpenCode CLI process wrapper for Cyrus",
 	"repository": {
 		"type": "git",

--- a/packages/simple-agent-runner/package.json
+++ b/packages/simple-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-simple-agent-runner",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Simple agent runner for enumerated responses",
 	"repository": {
 		"type": "git",

--- a/packages/slack-event-transport/package.json
+++ b/packages/slack-event-transport/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cyrus-slack-event-transport",
-	"version": "0.2.70",
+	"version": "0.2.71",
 	"description": "Slack event transport for receiving and verifying forwarded Slack webhooks",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary\n\n- prepare the coordinated Cyrus CLI v0.2.71 release\n- move public and internal Unreleased notes into the 2026-09-04 release section\n- bump all 16 public package manifests to 0.2.71\n- add the required CYPACK-1495 F1 release evidence\n\n## Validation\n\n- node scripts/release-packages.mjs validate 0.2.71\n- pnpm audit --audit-level=low\n- pnpm test:packages:run\n- pnpm lint\n- pnpm typecheck\n- pnpm build\n- F1 end-to-end release test drive\n\n## Release procedure\n\nAfter merge, dispatch release-cli.yml from main in dry-run mode, then perform the explicitly requested live release and verify npm, the published CLI, the tag, and GitHub Release.\n\nLinear: CYPACK-1495